### PR TITLE
feat(db): add User model fields for authentication

### DIFF
--- a/backend/prisma/migrations/20260513144002_add_user_fields/migration.sql
+++ b/backend/prisma/migrations/20260513144002_add_user_fields/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `name` on the `User` table. All the data in the column will be lost.
+  - Added the required column `displayName` to the `User` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `passwordHash` to the `User` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updatedAt` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "name",
+ADD COLUMN     "displayName" TEXT NOT NULL,
+ADD COLUMN     "passwordHash" TEXT NOT NULL,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -14,9 +14,11 @@ enum Status {
 
 model User {
   id        String   @id @default(cuid())
-  name      String
   email     String   @unique
+  passwordHash String
+  displayName String
   createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
   tasks     Task[]
 }
 


### PR DESCRIPTION
Adds the fields required for the auth foundation (`passwordHash`) and 
the auth-related profile fields (`displayName`, `updatedAt`) to the 
existing User model. Renames the existing `name` column to `displayName` 
to match the PRD.

## Changes

- `schema.prisma`: added `passwordHash`, `displayName`, `updatedAt`; 
  removed `name`
- `migrations/20260513144002_add_user_fields/`: drop-and-create for the 
  rename, three `ADD COLUMN NOT NULL` for the new fields

## Migration safety note

The migration adds three required columns (NOT NULL, no default) and 
drops one. This would fail on a table with existing rows, but all four 
target databases (local + dev/staging/prod on Railway) had empty User 
tables, so this was safe.

## Deploy status

Migration applied via `prisma migrate deploy` against:
- [x] Local Postgres (via `migrate dev`)
- [x] Railway development
- [x] Railway staging  
- [x] Railway production

## AC

Note: the issue title says "add User model" but the User model already 
existed in the schema. This PR adds the missing required fields and 
aligns the existing field names with the PRD.

Closes #35