### PR TITLE
feat(backend): add bcrypt password hashing utility

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "dependencies": {
         "@prisma/client": "^7.8.0",
+        "bcrypt": "^6.0.0",
         "express": "^4.22.1"
       },
       "devDependencies": {
+        "@types/bcrypt": "^6.0.0",
         "@types/express": "^4.17.25",
         "@types/node": "^20.19.39",
         "@types/supertest": "^6.0.2",
@@ -1540,6 +1542,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -2241,6 +2253,20 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/better-result": {
       "version": "2.9.0",
@@ -4185,6 +4211,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/npm-run-path": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,9 +13,11 @@
   },
   "dependencies": {
     "@prisma/client": "^7.8.0",
+    "bcrypt": "^6.0.0",
     "express": "^4.22.1"
   },
   "devDependencies": {
+    "@types/bcrypt": "^6.0.0",
     "@types/express": "^4.17.25",
     "@types/node": "^20.19.39",
     "@types/supertest": "^6.0.2",

--- a/backend/src/lib/password.ts
+++ b/backend/src/lib/password.ts
@@ -1,0 +1,11 @@
+import bcrypt from "bcrypt";
+
+const SALT_ROUNDS = 10;
+
+export async function hashPassword(plain: string): Promise<string> {
+  return bcrypt.hash(plain, SALT_ROUNDS);
+}
+
+export async function verifyPassword(plain: string, hash: string): Promise<boolean> {
+  return bcrypt.compare(plain, hash);
+}

--- a/backend/test/password.test.ts
+++ b/backend/test/password.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { hashPassword, verifyPassword } from "../src/lib/password";
+
+describe("hashPassword", () => {
+  it("returns a hash different from the input", async () => {
+    const hash = await hashPassword("secret");
+    expect(hash).not.toBe("secret");
+  });
+});
+
+describe("verifyPassword", () => {
+  it("returns true when the password matches the hash", async () => {
+    const hash = await hashPassword("secret");
+    expect(await verifyPassword("secret", hash)).toBe(true);
+  });
+
+  it("returns false when the password does not match the hash", async () => {
+    const hash = await hashPassword("secret");
+    expect(await verifyPassword("wrong", hash)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Installs `bcrypt` and `@types/bcrypt` in the backend
- Adds `src/lib/password.ts` with `hashPassword` and `verifyPassword` functions (10 salt rounds)
- Adds unit tests covering hash output, match, and mismatch cases

## No migration required
This PR adds TypeScript logic only. The `passwordHash` column already exists on the User model from #45.

## Test plan
- [x] `npm run test` — 6/6 tests pass including 3 new password tests
- [x] `npm run typecheck` — no errors
- [x] `npm run lint` — no errors

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)