### PR TITLE
feat(backend): add login endpoint

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { signup } from "../services/authService";
+import { signup, login } from "../services/authService";
 
 export async function signupController(req: Request, res: Response) {
   const { email, password, displayName } = req.body;
@@ -13,6 +13,22 @@ export async function signupController(req: Request, res: Response) {
     const prismaErr = err as { code?: string };
     if (prismaErr.code === "P2002") {
       return res.status(400).json({ success: false, error: "Email already in use" });
+    }
+    throw err;
+  }
+}
+
+export async function loginController(req: Request, res: Response) {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ success: false, error: "Missing required fields" });
+  }
+  try {
+    const data = await login(email, password);
+    return res.status(200).json({ success: true, data });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "INVALID_CREDENTIALS") {
+      return res.status(401).json({ success: false, error: "Invalid credentials" });
     }
     throw err;
   }

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,8 +1,9 @@
 import { Router } from "express";
-import { signupController } from "../controllers/authController";
+import { signupController, loginController } from "../controllers/authController";
 
 const router = Router();
 
 router.post("/signup", signupController);
+router.post("/login", loginController);
 
 export default router;

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -1,5 +1,5 @@
 import { prisma } from "../lib/prisma";
-import { hashPassword } from "../lib/password";
+import { hashPassword, verifyPassword } from "../lib/password";
 import { signToken } from "../lib/jwt";
 
 export async function signup(email: string, password: string, displayName: string) {
@@ -10,4 +10,22 @@ export async function signup(email: string, password: string, displayName: strin
   });
   const token = signToken(user.id);
   return { token, user };
+}
+
+export async function login(email: string, password: string) {
+  const found = await prisma.user.findUnique({ where: { email } });
+  if (!found) throw new Error("INVALID_CREDENTIALS");
+  const valid = await verifyPassword(password, found.passwordHash);
+  if (!valid) throw new Error("INVALID_CREDENTIALS");
+  const token = signToken(found.id);
+  return {
+    token,
+    user: {
+      id: found.id,
+      email: found.email,
+      displayName: found.displayName,
+      createdAt: found.createdAt,
+      updatedAt: found.updatedAt,
+    },
+  };
 }

--- a/backend/test/authService.test.ts
+++ b/backend/test/authService.test.ts
@@ -1,20 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockCreate = vi.hoisted(() => vi.fn());
+const mockFindUnique = vi.hoisted(() => vi.fn());
 
 vi.mock("../src/lib/prisma", () => ({
-  prisma: { user: { create: mockCreate } },
+  prisma: { user: { create: mockCreate, findUnique: mockFindUnique } },
 }));
 
 vi.mock("../src/lib/password", () => ({
   hashPassword: vi.fn().mockResolvedValue("hashed-password"),
+  verifyPassword: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock("../src/lib/jwt", () => ({
   signToken: vi.fn().mockReturnValue("mock-token"),
 }));
 
-import { signup } from "../src/services/authService";
+import { signup, login } from "../src/services/authService";
 
 const fakeUser = {
   id: "user-1",
@@ -22,6 +24,11 @@ const fakeUser = {
   displayName: "Test User",
   createdAt: new Date(),
   updatedAt: new Date(),
+};
+
+const fakeUserWithHash = {
+  ...fakeUser,
+  passwordHash: "hashed-password",
 };
 
 describe("signup", () => {
@@ -47,5 +54,30 @@ describe("signup", () => {
       },
       select: { id: true, email: true, displayName: true, createdAt: true, updatedAt: true },
     });
+  });
+});
+
+describe("login", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindUnique.mockResolvedValue(fakeUserWithHash);
+  });
+
+  it("returns token and user without passwordHash on valid credentials", async () => {
+    const result = await login("test@example.com", "secret");
+    expect(result.token).toBe("mock-token");
+    expect(result.user).not.toHaveProperty("passwordHash");
+    expect(result.user.email).toBe("test@example.com");
+  });
+
+  it("throws INVALID_CREDENTIALS when user is not found", async () => {
+    mockFindUnique.mockResolvedValue(null);
+    await expect(login("nobody@example.com", "secret")).rejects.toThrow("INVALID_CREDENTIALS");
+  });
+
+  it("throws INVALID_CREDENTIALS when password is wrong", async () => {
+    const { verifyPassword } = await import("../src/lib/password");
+    vi.mocked(verifyPassword).mockResolvedValueOnce(false);
+    await expect(login("test@example.com", "wrong")).rejects.toThrow("INVALID_CREDENTIALS");
   });
 });


### PR DESCRIPTION
## Summary
- `POST /api/v1/auth/login` accepts `email` and `password`
- Verifies credentials via `verifyPassword`; returns 401 on invalid credentials
- Returns JWT and user object (no `passwordHash`) on success
- Follows route → controller → service pattern

## Test plan
- [x] `npm test` passes all 14 tests including 3 new login service tests
- [x] Valid credentials return 200 + JWT
- [x] Wrong password or unknown email return 401
- [x] Missing fields return 400

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)