### PR TITLE
feat(backend): add auth middleware

### DIFF
--- a/backend/src/@types/express/index.d.ts
+++ b/backend/src/@types/express/index.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  namespace Express {
+    interface Request {
+      userId?: string;
+    }
+  }
+}
+
+export {};

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import taskRouter from "./routes/tasks";
 import authRouter from "./routes/auth";
+import { requireAuth } from "./middleware/auth";
 
 const app = express();
 
@@ -10,7 +11,7 @@ app.get("/health", (_req, res) => {
   res.status(200).json({ status: "ok" });
 });
 
-app.use("/api/v1/tasks", taskRouter);
+app.use("/api/v1/tasks", requireAuth, taskRouter);
 app.use("/api/v1/auth", authRouter);
 
 export default app;

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from "express";
+import { verifyToken } from "../lib/jwt";
+
+export function requireAuth(req: Request, res: Response, next: NextFunction) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith("Bearer ")) {
+    return res.status(401).json({ success: false, error: "Unauthorized" });
+  }
+  const token = authHeader.slice(7);
+  try {
+    const payload = verifyToken(token);
+    req.userId = payload.sub as string;
+    next();
+  } catch {
+    return res.status(401).json({ success: false, error: "Unauthorized" });
+  }
+}

--- a/backend/test/auth.middleware.test.ts
+++ b/backend/test/auth.middleware.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+
+vi.mock("../src/lib/jwt", () => ({
+  verifyToken: vi.fn().mockReturnValue({ sub: "user-1" }),
+}));
+
+import { requireAuth } from "../src/middleware/auth";
+import { verifyToken } from "../src/lib/jwt";
+
+function makeReq(authHeader?: string): Partial<Request> {
+  return { headers: { authorization: authHeader } };
+}
+
+function makeRes(): { status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn> } {
+  const json = vi.fn();
+  const status = vi.fn().mockReturnValue({ json });
+  return { status, json };
+}
+
+describe("requireAuth", () => {
+  const next = vi.fn() as unknown as NextFunction;
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when Authorization header is missing", () => {
+    const req = makeReq();
+    const res = makeRes();
+    requireAuth(req as Request, res as unknown as Response, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when token is invalid", () => {
+    vi.mocked(verifyToken).mockImplementationOnce(() => { throw new Error("bad token"); });
+    const req = makeReq("Bearer bad.token.here");
+    const res = makeRes();
+    requireAuth(req as Request, res as unknown as Response, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("attaches userId and calls next on valid token", () => {
+    const req = makeReq("Bearer valid.token.here") as Request;
+    const res = makeRes();
+    requireAuth(req, res as unknown as Response, next);
+    expect(req.userId).toBe("user-1");
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- `requireAuth` middleware reads `Authorization: Bearer <token>` header
- Verifies JWT via `verifyToken` and attaches `userId` to the request object
- Returns 401 on missing header or invalid token
- Applied to `/api/v1/tasks` as the first protected route

## Test plan
- [x] `npm test` passes all 17 tests including 3 new middleware unit tests
- [x] Request with valid JWT passes through to the route
- [x] Missing or invalid token returns 401

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)