### PR TITLE
feat(frontend): add signup and login pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ PORT=3000
 
 # Base URL of the backend API, used by the Vite frontend to make requests
 VITE_API_URL=http://localhost:3000
+
+# Allowed frontend origin for CORS (set to the deployed frontend URL in staging/prod)
+CORS_ORIGIN=http://localhost:5173

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,10 +7,12 @@
     "": {
       "name": "backend",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
         "bcrypt": "^6.0.0",
+        "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^4.22.1",
         "jsonwebtoken": "^9.0.3",
@@ -18,6 +20,7 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^6.0.0",
+        "@types/cors": "^2.8.19",
         "@types/express": "^4.17.25",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20.19.39",
@@ -1606,6 +1609,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2675,6 +2688,23 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4413,6 +4443,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "bcrypt": "^6.0.0",
+    "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^4.22.1",
     "jsonwebtoken": "^9.0.3",
@@ -23,6 +24,7 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
+    "@types/cors": "^2.8.19",
     "@types/express": "^4.17.25",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.19.39",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,10 +1,12 @@
 import express from "express";
+import cors from "cors";
 import taskRouter from "./routes/tasks";
 import authRouter from "./routes/auth";
 import { requireAuth } from "./middleware/auth";
 
 const app = express();
 
+app.use(cors({ origin: process.env.CORS_ORIGIN }));
 app.use(express.json());
 
 app.get("/health", (_req, res) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import type { Task } from "./types";
+import SignupPage from "./pages/SignupPage";
+import LoginPage from "./pages/LoginPage";
 
 function TaskCard({ task }: { task: Task }) {
   return (
@@ -19,9 +21,13 @@ export default function App() {
     { id: "3", title: "Connect to the backend", completed: false },
   ]);
 
+  const path = window.location.pathname;
+  if (path === "/signup") return <SignupPage />;
+  if (path === "/login") return <LoginPage />;
+
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center p-8">
-      <h1 className="text-4xl font-bold text-gray-900 mb-8">Impact Training</h1>
+      <h1 className="text-4xl font-bold text-gray-900 mb-8">Code Impact Training</h1>
       <div className="w-full max-w-md">
         {tasks.map((task) => (
           <TaskCard key={task.id} task={task} />

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import type { FormEvent } from "react";
+import { apiFetch } from "../lib/api";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const res = await apiFetch("/api/v1/auth/login", {
+      method: "POST",
+      body: JSON.stringify({ email, password }),
+    });
+    const data = (await res.json()) as { data?: { token: string }; error?: string };
+    if (!res.ok) {
+      setError(data.error ?? "Login failed");
+      return;
+    }
+    localStorage.setItem("token", data.data!.token);
+    window.location.href = "/";
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-8">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 w-full max-w-md"
+      >
+        <h1 className="text-2xl font-bold text-gray-900 mb-6">Log in</h1>
+        {error && <p className="text-red-600 text-sm mb-4">{error}</p>}
+        <label className="block mb-4">
+          <span className="text-sm font-medium text-gray-700">Email</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="block mb-6">
+          <span className="text-sm font-medium text-gray-700">Password</span>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+          />
+        </label>
+        <button
+          type="submit"
+          className="w-full bg-gray-900 text-white rounded px-4 py-2 text-sm font-medium hover:bg-gray-700"
+        >
+          Log in
+        </button>
+        <p className="text-sm text-gray-500 mt-4 text-center">
+          Don&apos;t have an account?{" "}
+          <a href="/signup" className="text-gray-900 font-medium hover:underline">
+            Sign up
+          </a>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import type { FormEvent } from "react";
+import { apiFetch } from "../lib/api";
+
+export default function SignupPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const res = await apiFetch("/api/v1/auth/signup", {
+      method: "POST",
+      body: JSON.stringify({ email, password, displayName }),
+    });
+    const data = (await res.json()) as { data?: { token: string }; error?: string };
+    if (!res.ok) {
+      setError(data.error ?? "Signup failed");
+      return;
+    }
+    localStorage.setItem("token", data.data!.token);
+    window.location.href = "/";
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-8">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 w-full max-w-md"
+      >
+        <h1 className="text-2xl font-bold text-gray-900 mb-6">Sign up</h1>
+        {error && <p className="text-red-600 text-sm mb-4">{error}</p>}
+        <label className="block mb-4">
+          <span className="text-sm font-medium text-gray-700">Display name</span>
+          <input
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="block mb-4">
+          <span className="text-sm font-medium text-gray-700">Email</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="block mb-6">
+          <span className="text-sm font-medium text-gray-700">Password</span>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+          />
+        </label>
+        <button
+          type="submit"
+          className="w-full bg-gray-900 text-white rounded px-4 py-2 text-sm font-medium hover:bg-gray-700"
+        >
+          Create account
+        </button>
+        <p className="text-sm text-gray-500 mt-4 text-center">
+          Already have an account?{" "}
+          <a href="/login" className="text-gray-900 font-medium hover:underline">
+            Log in
+          </a>
+        </p>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `SignupPage` at `/signup` — email, password, displayName fields; posts to `/api/v1/auth/signup`; stores JWT and redirects to `/` on success; error display; link to `/login`
- `LoginPage` at `/login` — email, password fields; posts to `/api/v1/auth/login`; same token/redirect/error pattern; link to `/signup`
- `App.tsx` routes `/signup` and `/login` via `window.location.pathname`
- CORS middleware added to backend, origin read from `CORS_ORIGIN` env var
- `CORS_ORIGIN=http://localhost:5173` added to `.env.example`

## Test plan
- [x] `/signup` creates account, stores token, redirects to `/`
- [x] `/login` authenticates, stores token, redirects to `/`
- [x] Invalid credentials show error message
- [x] Links between pages work

Closes #42
Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)