### PR TITLE
feat(frontend): add route protection and logout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { Task } from "./types";
 import SignupPage from "./pages/SignupPage";
 import LoginPage from "./pages/LoginPage";
@@ -22,12 +22,35 @@ export default function App() {
   ]);
 
   const path = window.location.pathname;
+  const isPublic = path === "/signup" || path === "/login";
+  const token = localStorage.getItem("token");
+
+  useEffect(() => {
+    if (!isPublic && !token) {
+      window.location.href = "/login";
+    }
+  }, [isPublic, token]);
+
   if (path === "/signup") return <SignupPage />;
   if (path === "/login") return <LoginPage />;
+  if (!token) return null;
+
+  function handleSignOut() {
+    localStorage.removeItem("token");
+    window.location.href = "/login";
+  }
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center p-8">
-      <h1 className="text-4xl font-bold text-gray-900 mb-8">Code Impact Training</h1>
+      <div className="w-full max-w-md flex justify-between items-center mb-8">
+        <h1 className="text-4xl font-bold text-gray-900">Code Impact Training</h1>
+        <button
+          onClick={handleSignOut}
+          className="text-sm text-gray-500 hover:text-gray-900 underline"
+        >
+          Sign out
+        </button>
+      </div>
       <div className="w-full max-w-md">
         {tasks.map((task) => (
           <TaskCard key={task.id} task={task} />


### PR DESCRIPTION
## Summary
- All routes except `/login` and `/signup` redirect to `/login` if no token in localStorage
- Redirect handled in `useEffect` (side-effect safe); `return null` prevents flash while redirecting
- Sign out button clears token from localStorage and redirects to `/login`

## Test plan
- [x] Visiting `/` without a token redirects to `/login`
- [x] Visiting `/signup` or `/login` without a token works normally
- [x] Sign out button clears token and redirects to `/login`

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)