### PR TITLE
fix(docker): run prisma migrations on startup and proxy API calls to …

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,5 +22,5 @@ RUN npm run build
 # Expose port 3000 so the container can be reached
 EXPOSE 3000
 
-# Start the compiled server
-CMD ["node", "dist/index.js"]
+# Apply pending migrations then start the compiled server
+CMD ["sh", "-c", "npx prisma migrate deploy && node dist/index.js"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,12 @@ export default defineConfig({
   },
   server: {
     host: true,
+    proxy: {
+      "/api": {
+        target: "http://backend:3000",
+        changeOrigin: true,
+      },
+    },
     allowedHosts: [
       "frontend-development-f04a.up.railway.app",
       "frontend-stag-staging.up.railway.app",


### PR DESCRIPTION
…backend

- Backend CMD now runs `prisma migrate deploy` before starting the server so the database schema is created on first boot
- Vite dev server proxies `/api` requests to `http://backend:3000` so the browser resolves API calls correctly inside Docker