### PR TITLE
fix(docker): pass JWT_SECRET from .env into backend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - "3000:3000"
     environment:
       DATABASE_URL: postgresql://postgres:password@db:5432/orbit
+      JWT_SECRET: ${JWT_SECRET}
     depends_on:
       - db
 


### PR DESCRIPTION
Docker Compose substitutes ${JWT_SECRET} from the root .env file at runtime so the value is never committed to source control.