### PR TITLE
fix(backend): copy prisma.config.ts before npm install in Docker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,7 +7,8 @@ WORKDIR /app
 # Copy package files first (for better caching)
 COPY package*.json ./
 
-# Copy the Prisma schema so postinstall's `prisma generate` can find it
+# Copy Prisma config and schema so postinstall's `prisma generate` can find them
+COPY prisma.config.ts ./
 COPY prisma ./prisma
 
 # Install all dependencies


### PR DESCRIPTION
Prisma 7 reads prisma.config.ts to locate the schema. The postinstall hook runs `prisma generate` during `npm install`, which failed on Railway because prisma.config.ts and prisma/ weren't in the image yet. Copy both before npm install so the schema is resolvable at build time.