### PR TITLE
fix(ci): use RAILWAY_API_TOKEN for account-scoped deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,8 +66,8 @@ jobs:
       - name: Deploy backend
         run: railway up --service "$BACKEND_SERVICE" --environment "${{ inputs.environment }}" --project "$RAILWAY_PROJECT"
         env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
       - name: Deploy frontend
         run: railway up --service "$FRONTEND_SERVICE" --environment "${{ inputs.environment }}" --project "$RAILWAY_PROJECT"
         env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}


### PR DESCRIPTION
railway up with --project/--environment targeting arbitrary environments requires an account-scoped token, which the CLI reads from RAILWAY_API_TOKEN, not RAILWAY_TOKEN (the latter is for project-scoped tokens). Match the workflow to the account token now stored in the RAILWAY_API_TOKEN secret.