### PR TITLE
feat(db): add Task model with UPCOMING/COMPLETED status

### DIFF
--- a/backend/prisma/migrations/20260529033047_add_task_model/migration.sql
+++ b/backend/prisma/migrations/20260529033047_add_task_model/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - The values [TODO,IN_PROGRESS,DONE] on the enum `Status` will be removed. If these variants are still used in the database, this will fail.
+  - You are about to drop the column `completed` on the `Task` table. All the data in the column will be lost.
+  - Added the required column `updatedAt` to the `Task` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "Status_new" AS ENUM ('UPCOMING', 'COMPLETED');
+ALTER TABLE "public"."Task" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TABLE "Task" ALTER COLUMN "status" TYPE "Status_new" USING ("status"::text::"Status_new");
+ALTER TYPE "Status" RENAME TO "Status_old";
+ALTER TYPE "Status_new" RENAME TO "Status";
+DROP TYPE "public"."Status_old";
+ALTER TABLE "Task" ALTER COLUMN "status" SET DEFAULT 'UPCOMING';
+COMMIT;
+
+-- AlterTable
+ALTER TABLE "Task" DROP COLUMN "completed",
+ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL,
+ALTER COLUMN "status" SET DEFAULT 'UPCOMING';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -7,9 +7,8 @@ datasource db {
 }
 
 enum Status {
-  TODO
-  IN_PROGRESS
-  DONE
+  UPCOMING
+  COMPLETED
 }
 
 model User {
@@ -25,9 +24,10 @@ model User {
 model Task {
   id        String    @id @default(cuid())
   title     String
-  completed Boolean   @default(false)
   dueDate   DateTime?
-  status    Status    @default(TODO)
+  status    Status    @default(UPCOMING)
   userId    String
   user      User      @relation(fields: [userId], references: [id])
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
 }


### PR DESCRIPTION
## Summary
- Updates `Status` enum to `UPCOMING` / `COMPLETED` (replaces `TODO`, `IN_PROGRESS`, `DONE`)
- Removes redundant `completed` boolean from `Task` model
- Adds `createdAt` and `updatedAt` to `Task` model
- Includes migration `20260529033047_add_task_model` applied to dev database

## Test plan
- [x] `npx prisma migrate status` shows no pending migrations
- [x] `npx prisma validate` passes
- [x] Schema fields match AC: `id`, `title`, `status`, `dueDate?`, `userId`, `createdAt`, `updatedAt`

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)