### PR TITLE
feat(backend): add task CRUD endpoints

### DIFF
--- a/backend/src/controllers/taskController.ts
+++ b/backend/src/controllers/taskController.ts
@@ -1,7 +1,68 @@
 import { Request, Response } from "express";
-import { getTasks } from "../services/taskService";
+import { Status } from "@prisma/client";
+import {
+  getTasks,
+  getTask,
+  createTask,
+  updateTask,
+  deleteTask,
+} from "../services/taskService";
 
-export function getTasksController(req: Request, res: Response) {
-  const data = getTasks();
+export async function getTasksController(req: Request, res: Response) {
+  const data = await getTasks(req.userId!);
   res.json({ success: true, data });
+}
+
+export async function getTaskController(req: Request, res: Response) {
+  try {
+    const data = await getTask(req.params.id, req.userId!);
+    res.json({ success: true, data });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "NOT_FOUND") {
+      return res.status(404).json({ success: false, error: "Task not found" });
+    }
+    throw err;
+  }
+}
+
+export async function createTaskController(req: Request, res: Response) {
+  const { title, dueDate } = req.body;
+  if (!title) {
+    return res.status(400).json({ success: false, error: "Missing required fields" });
+  }
+  const data = await createTask(
+    req.userId!,
+    title,
+    dueDate ? new Date(dueDate) : undefined
+  );
+  res.status(201).json({ success: true, data });
+}
+
+export async function updateTaskController(req: Request, res: Response) {
+  try {
+    const { title, status, dueDate } = req.body;
+    const fields: { title?: string; status?: Status; dueDate?: Date | null } = {};
+    if (title !== undefined) fields.title = title;
+    if (status !== undefined) fields.status = status;
+    if (dueDate !== undefined) fields.dueDate = dueDate ? new Date(dueDate) : null;
+    const data = await updateTask(req.params.id, req.userId!, fields);
+    res.json({ success: true, data });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "NOT_FOUND") {
+      return res.status(404).json({ success: false, error: "Task not found" });
+    }
+    throw err;
+  }
+}
+
+export async function deleteTaskController(req: Request, res: Response) {
+  try {
+    await deleteTask(req.params.id, req.userId!);
+    res.status(204).send();
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "NOT_FOUND") {
+      return res.status(404).json({ success: false, error: "Task not found" });
+    }
+    throw err;
+  }
 }

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -1,8 +1,18 @@
 import { Router } from "express";
-import { getTasksController } from "../controllers/taskController";
+import {
+  getTasksController,
+  getTaskController,
+  createTaskController,
+  updateTaskController,
+  deleteTaskController,
+} from "../controllers/taskController";
 
 const router = Router();
 
 router.get("/", getTasksController);
+router.get("/:id", getTaskController);
+router.post("/", createTaskController);
+router.patch("/:id", updateTaskController);
+router.delete("/:id", deleteTaskController);
 
 export default router;

--- a/backend/src/services/taskService.ts
+++ b/backend/src/services/taskService.ts
@@ -1,6 +1,36 @@
-export function getTasks() {
-  return [];
+import { Status } from "@prisma/client";
+import { prisma } from "../lib/prisma";
+
+export async function getTasks(userId: string) {
+  return prisma.task.findMany({ where: { userId } });
 }
+
+export async function getTask(id: string, userId: string) {
+  const task = await prisma.task.findFirst({ where: { id, userId } });
+  if (!task) throw new Error("NOT_FOUND");
+  return task;
+}
+
+export async function createTask(userId: string, title: string, dueDate?: Date) {
+  return prisma.task.create({ data: { title, userId, dueDate } });
+}
+
+export async function updateTask(
+  id: string,
+  userId: string,
+  fields: { title?: string; status?: Status; dueDate?: Date | null }
+) {
+  const task = await prisma.task.findFirst({ where: { id, userId } });
+  if (!task) throw new Error("NOT_FOUND");
+  return prisma.task.update({ where: { id }, data: fields });
+}
+
+export async function deleteTask(id: string, userId: string) {
+  const task = await prisma.task.findFirst({ where: { id, userId } });
+  if (!task) throw new Error("NOT_FOUND");
+  await prisma.task.delete({ where: { id } });
+}
+
 export function isOverdue(dueDate: Date): boolean {
   return dueDate < new Date();
 }


### PR DESCRIPTION
## Summary
- Implements all 5 task endpoints: `POST`, `GET`, `GET /:id`, `PATCH /:id`, `DELETE /:id`
- Follows route → controller → service pattern, consistent with auth layer
- All queries scoped to `req.userId` — users cannot access each other's tasks
- Auth already enforced via `requireAuth` middleware in `app.ts`

## Status codes
| Endpoint | Success | Errors |
|---|---|---|
| POST /tasks | 201 | 400 missing title |
| GET /tasks | 200 | — |
| GET /tasks/:id | 200 | 404 not found |
| PATCH /tasks/:id | 200 | 404 not found |
| DELETE /tasks/:id | 204 | 404 not found |
| Any without JWT | 401 | — |

## Test plan
- [x] 17 existing tests still pass (`npm test`)
- [x] POST creates a task scoped to the authenticated user
- [x] GET returns only the current user's tasks
- [x] PATCH/:id returns 404 for another user's task
- [x] DELETE/:id returns 404 for another user's task
- [x] Unauthenticated requests return 401

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)