### PR TITLE
feat(backend): add complete task endpoint

### DIFF
--- a/backend/src/controllers/taskController.ts
+++ b/backend/src/controllers/taskController.ts
@@ -6,6 +6,7 @@ import {
   createTask,
   updateTask,
   deleteTask,
+  completeTask,
 } from "../services/taskService";
 
 export async function getTasksController(req: Request, res: Response) {
@@ -46,6 +47,18 @@ export async function updateTaskController(req: Request, res: Response) {
     if (status !== undefined) fields.status = status;
     if (dueDate !== undefined) fields.dueDate = dueDate ? new Date(dueDate) : null;
     const data = await updateTask(req.params.id, req.userId!, fields);
+    res.json({ success: true, data });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "NOT_FOUND") {
+      return res.status(404).json({ success: false, error: "Task not found" });
+    }
+    throw err;
+  }
+}
+
+export async function completeTaskController(req: Request, res: Response) {
+  try {
+    const data = await completeTask(req.params.id, req.userId!);
     res.json({ success: true, data });
   } catch (err: unknown) {
     if (err instanceof Error && err.message === "NOT_FOUND") {

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -5,6 +5,7 @@ import {
   createTaskController,
   updateTaskController,
   deleteTaskController,
+  completeTaskController,
 } from "../controllers/taskController";
 
 const router = Router();
@@ -13,6 +14,7 @@ router.get("/", getTasksController);
 router.get("/:id", getTaskController);
 router.post("/", createTaskController);
 router.patch("/:id", updateTaskController);
+router.patch("/:id/complete", completeTaskController);
 router.delete("/:id", deleteTaskController);
 
 export default router;

--- a/backend/src/services/taskService.ts
+++ b/backend/src/services/taskService.ts
@@ -31,6 +31,12 @@ export async function deleteTask(id: string, userId: string) {
   await prisma.task.delete({ where: { id } });
 }
 
+export async function completeTask(id: string, userId: string) {
+  const task = await prisma.task.findFirst({ where: { id, userId } });
+  if (!task) throw new Error("NOT_FOUND");
+  return prisma.task.update({ where: { id }, data: { status: Status.COMPLETED } });
+}
+
 export function isOverdue(dueDate: Date): boolean {
   return dueDate < new Date();
 }


### PR DESCRIPTION
## Summary
- Adds `PATCH /api/v1/tasks/:id/complete` endpoint that sets task status to `COMPLETED`
- Returns 404 if task doesn't exist or belongs to another user
- Requires valid JWT (protected by existing auth middleware)
- Also ran `prisma generate` to sync the Prisma client with the current schema (was stale with old enum values)

## Test plan
- [x] `PATCH /api/v1/tasks/:id/complete` returns the updated task with `status: COMPLETED`
- [x] Returns 404 for a non-existent task ID
- [x] Returns 404 for a task belonging to a different user
- [x] Returns 401 without a valid JWT

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)