### PR TITLE
feat(frontend): add Tasks page with create and list

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,26 +1,10 @@
-import { useState, useEffect } from "react";
-import type { Task } from "./types";
+import { useEffect } from "react";
 import SignupPage from "./pages/SignupPage";
 import LoginPage from "./pages/LoginPage";
-
-function TaskCard({ task }: { task: Task }) {
-  return (
-    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-5 mb-4 w-full max-w-md">
-      <h2 className="text-lg font-semibold text-gray-900">{task.title}</h2>
-      <p className="text-sm text-gray-500 mt-1">
-        {task.completed ? "Done" : "Not completed"}
-      </p>
-    </div>
-  );
-}
+import TasksPage from "./pages/TasksPage";
+import Layout from "./components/Layout";
 
 export default function App() {
-  const [tasks] = useState<Task[]>([
-    { id: "1", title: "Set up the project", completed: true },
-    { id: "2", title: "Build the TaskCard component", completed: true },
-    { id: "3", title: "Connect to the backend", completed: false },
-  ]);
-
   const path = window.location.pathname;
   const isPublic = path === "/signup" || path === "/login";
   const token = localStorage.getItem("token");
@@ -34,28 +18,21 @@ export default function App() {
   if (path === "/signup") return <SignupPage />;
   if (path === "/login") return <LoginPage />;
   if (!token) return null;
-
-  function handleSignOut() {
-    localStorage.removeItem("token");
-    window.location.href = "/login";
-  }
+  if (path === "/tasks") return <TasksPage />;
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center p-8">
-      <div className="w-full max-w-md flex justify-between items-center mb-8">
-        <h1 className="text-4xl font-bold text-gray-900">Code Impact Training</h1>
-        <button
-          onClick={handleSignOut}
-          className="text-sm text-gray-500 hover:text-gray-900 underline"
+    <Layout>
+      <h1 className="text-5xl font-bold text-gray-900 text-center mt-12 mb-16">
+        Code Impact Training
+      </h1>
+      <div className="flex flex-col items-center gap-4">
+        <a
+          href="/tasks"
+          className="inline-block bg-gray-900 text-white text-base font-medium px-10 py-3 rounded hover:bg-gray-700 transition-colors duration-150"
         >
-          Sign out
-        </button>
+          Go to Tasks
+        </a>
       </div>
-      <div className="w-full max-w-md">
-        {tasks.map((task) => (
-          <TaskCard key={task.id} task={task} />
-        ))}
-      </div>
-    </div>
+    </Layout>
   );
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+function handleSignOut() {
+  localStorage.removeItem("token");
+  window.location.href = "/login";
+}
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col p-8">
+      <div className="w-full flex justify-end mb-4">
+        <button
+          onClick={handleSignOut}
+          className="text-sm font-medium text-gray-600 border border-gray-300 bg-white px-4 py-2 rounded hover:bg-gray-200 transition-colors duration-150"
+        >
+          Sign out
+        </button>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,1 +1,9 @@
 @import "tailwindcss";
+
+@layer base {
+  button {
+    cursor: pointer;
+    transition: background-color 150ms ease, color 150ms ease, border-color 150ms ease, opacity 150ms ease;
+  }
+}
+

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -53,7 +53,7 @@ export default function LoginPage() {
         </label>
         <button
           type="submit"
-          className="w-full bg-gray-900 text-white rounded px-4 py-2 text-sm font-medium hover:bg-gray-700"
+          className="w-full bg-gray-900 text-white rounded px-4 py-2 text-sm font-medium hover:bg-gray-700 transition-colors duration-150"
         >
           Log in
         </button>

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -64,7 +64,7 @@ export default function SignupPage() {
         </label>
         <button
           type="submit"
-          className="w-full bg-gray-900 text-white rounded px-4 py-2 text-sm font-medium hover:bg-gray-700"
+          className="w-full bg-gray-900 text-white rounded px-4 py-2 text-sm font-medium hover:bg-gray-700 transition-colors duration-150"
         >
           Create account
         </button>

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -43,7 +43,13 @@ export default function TasksPage() {
   }
 
   useEffect(() => {
-    fetchTasks();
+    async function load() {
+      const res = await apiFetch("/api/v1/tasks");
+      if (!res.ok) return;
+      const data = (await res.json()) as { data: Task[] };
+      setTasks(data.data);
+    }
+    void load();
   }, []);
 
   async function handleCreate(e: FormEvent) {

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -1,0 +1,137 @@
+import { useState, useEffect } from "react";
+import type { FormEvent } from "react";
+import type { Task } from "../types";
+import { apiFetch } from "../lib/api";
+import Layout from "../components/Layout";
+
+function Section({ title, tasks }: { title: string; tasks: Task[] }) {
+  if (tasks.length === 0) return null;
+  return (
+    <div className="mb-8">
+      <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
+        {title}
+      </h2>
+      {tasks.map((task) => (
+        <div
+          key={task.id}
+          className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 mb-2"
+        >
+          <p className="text-gray-900 font-medium">{task.title}</p>
+          {task.dueDate && (
+            <p className="text-xs text-gray-400 mt-1">
+              Due {new Date(task.dueDate).toLocaleDateString()}
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function TasksPage() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [showForm, setShowForm] = useState(false);
+  const [title, setTitle] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  async function fetchTasks() {
+    const res = await apiFetch("/api/v1/tasks");
+    if (!res.ok) return;
+    const data = (await res.json()) as { data: Task[] };
+    setTasks(data.data);
+  }
+
+  useEffect(() => {
+    fetchTasks();
+  }, []);
+
+  async function handleCreate(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const res = await apiFetch("/api/v1/tasks", {
+      method: "POST",
+      body: JSON.stringify({ title, dueDate: dueDate || undefined }),
+    });
+    const data = (await res.json()) as { error?: string };
+    if (!res.ok) {
+      setError(data.error ?? "Failed to create task");
+      return;
+    }
+    setTitle("");
+    setDueDate("");
+    setShowForm(false);
+    await fetchTasks();
+  }
+
+  const now = new Date();
+  const overdue = tasks.filter(
+    (t) => t.status === "UPCOMING" && t.dueDate && new Date(t.dueDate) < now
+  );
+  const upcoming = tasks.filter(
+    (t) => t.status === "UPCOMING" && (!t.dueDate || new Date(t.dueDate) >= now)
+  );
+  const completed = tasks.filter((t) => t.status === "COMPLETED");
+
+  return (
+    <Layout>
+      <div className="flex flex-col items-center">
+        <div className="w-full max-w-md flex justify-between items-center mb-8">
+          <h1 className="text-2xl font-bold text-gray-900">Tasks</h1>
+          <button
+            onClick={() => setShowForm((v) => !v)}
+            className="text-sm font-medium text-gray-600 border border-gray-300 bg-white px-4 py-2 rounded hover:bg-gray-200 transition-colors duration-150"
+          >
+            {showForm ? "Cancel" : "+ Add task"}
+          </button>
+        </div>
+
+        {showForm && (
+          <form
+            onSubmit={handleCreate}
+            className="bg-white rounded-lg shadow-sm border border-gray-200 p-5 w-full max-w-md mb-8"
+          >
+            {error && <p className="text-red-600 text-sm mb-3">{error}</p>}
+            <label className="block mb-3">
+              <span className="text-sm font-medium text-gray-700">Title</span>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                required
+                autoFocus
+                className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+              />
+            </label>
+            <label className="block mb-4">
+              <span className="text-sm font-medium text-gray-700">
+                Due date <span className="text-gray-400 font-normal">(optional)</span>
+              </span>
+              <input
+                type="date"
+                value={dueDate}
+                onChange={(e) => setDueDate(e.target.value)}
+                className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+              />
+            </label>
+            <button
+              type="submit"
+              className="w-full bg-gray-900 text-white rounded px-4 py-2 text-sm font-medium hover:bg-gray-700 transition-colors duration-150"
+            >
+              Save task
+            </button>
+          </form>
+        )}
+
+        <div className="w-full max-w-md">
+          <Section title="Overdue" tasks={overdue} />
+          <Section title="Upcoming" tasks={upcoming} />
+          <Section title="Completed" tasks={completed} />
+          {tasks.length === 0 && !showForm && (
+            <p className="text-sm text-gray-400 text-center">No tasks yet.</p>
+          )}
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,6 +1,6 @@
 export type Task = {
   id: string;
   title: string;
-  completed: boolean;
-  dueDate?: Date;
+  status: "UPCOMING" | "COMPLETED";
+  dueDate?: string | null;
 };


### PR DESCRIPTION
## Summary
- Adds `/tasks` route with Overdue, Upcoming, and Completed sections
- Collapsible "+ Add task" form that opens inline and dismisses after save
- Shared `Layout` component with universal sign out button across all authenticated pages
- Updated `Task` type to match backend shape (`status: UPCOMING | COMPLETED`)
- Smooth hover transitions on all buttons + `cursor: pointer` globally

## Test plan
- [x] `/tasks` loads and fetches tasks from the API
- [x] Tasks appear in the correct section (Overdue/Upcoming/Completed)
- [x] "+ Add task" toggles the form open/closed
- [x] Creating a task POSTs to the API and refreshes the list
- [x] Sign out button appears on every authenticated page
- [x] All buttons show pointer cursor and color transition on hover

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)