### PR TITLE
feat(frontend): add edit, complete, delete task UI

### DIFF
--- a/backend/prisma/migrations/20260529042439_add_task_description/migration.sql
+++ b/backend/prisma/migrations/20260529042439_add_task_description/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Task" ADD COLUMN     "description" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,12 +22,13 @@ model User {
 }
 
 model Task {
-  id        String    @id @default(cuid())
-  title     String
-  dueDate   DateTime?
-  status    Status    @default(UPCOMING)
-  userId    String
-  user      User      @relation(fields: [userId], references: [id])
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
+  id          String    @id @default(cuid())
+  title       String
+  description String?
+  dueDate     DateTime?
+  status      Status    @default(UPCOMING)
+  userId      String
+  user        User      @relation(fields: [userId], references: [id])
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
 }

--- a/backend/src/controllers/taskController.ts
+++ b/backend/src/controllers/taskController.ts
@@ -41,9 +41,10 @@ export async function createTaskController(req: Request, res: Response) {
 
 export async function updateTaskController(req: Request, res: Response) {
   try {
-    const { title, status, dueDate } = req.body;
-    const fields: { title?: string; status?: Status; dueDate?: Date | null } = {};
+    const { title, description, status, dueDate } = req.body;
+    const fields: { title?: string; description?: string | null; status?: Status; dueDate?: Date | null } = {};
     if (title !== undefined) fields.title = title;
+    if (description !== undefined) fields.description = description;
     if (status !== undefined) fields.status = status;
     if (dueDate !== undefined) fields.dueDate = dueDate ? new Date(dueDate) : null;
     const data = await updateTask(req.params.id, req.userId!, fields);

--- a/backend/src/services/taskService.ts
+++ b/backend/src/services/taskService.ts
@@ -18,7 +18,7 @@ export async function createTask(userId: string, title: string, dueDate?: Date) 
 export async function updateTask(
   id: string,
   userId: string,
-  fields: { title?: string; status?: Status; dueDate?: Date | null }
+  fields: { title?: string; description?: string | null; status?: Status; dueDate?: Date | null }
 ) {
   const task = await prisma.task.findFirst({ where: { id, userId } });
   if (!task) throw new Error("NOT_FOUND");

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -4,36 +4,218 @@ import type { Task } from "../types";
 import { apiFetch } from "../lib/api";
 import Layout from "../components/Layout";
 
-function Section({ title, tasks }: { title: string; tasks: Task[] }) {
-  if (tasks.length === 0) return null;
+function TaskCard({
+  task,
+  onRefresh,
+  onDeleted,
+}: {
+  task: Task;
+  onRefresh: () => Promise<void>;
+  onDeleted: (task: Task) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState(task.title);
+  const [editDescription, setEditDescription] = useState(task.description ?? "");
+  const [editDueDate, setEditDueDate] = useState(
+    task.dueDate ? task.dueDate.slice(0, 10) : ""
+  );
+
+  function openEdit() {
+    setEditTitle(task.title);
+    setEditDescription(task.description ?? "");
+    setEditDueDate(task.dueDate ? task.dueDate.slice(0, 10) : "");
+    setEditing(true);
+  }
+
+  async function handleComplete() {
+    const res = await apiFetch(`/api/v1/tasks/${task.id}/complete`, {
+      method: "PATCH",
+    });
+    if (res.ok) await onRefresh();
+  }
+
+  async function handleDelete() {
+    const res = await apiFetch(`/api/v1/tasks/${task.id}`, {
+      method: "DELETE",
+    });
+    if (res.ok) {
+      onDeleted(task);
+      await onRefresh();
+    }
+  }
+
+  async function handleEdit(e: FormEvent) {
+    e.preventDefault();
+    const res = await apiFetch(`/api/v1/tasks/${task.id}`, {
+      method: "PATCH",
+      body: JSON.stringify({
+        title: editTitle,
+        description: editDescription || null,
+        dueDate: editDueDate || null,
+      }),
+    });
+    if (res.ok) {
+      setEditing(false);
+      await onRefresh();
+    }
+  }
+
+  if (editing) {
+    return (
+      <form
+        onSubmit={handleEdit}
+        className="bg-white rounded-lg shadow-sm border border-gray-300 p-4 mb-2"
+      >
+        <label className="block mb-2">
+          <span className="text-xs font-medium text-gray-500">Title</span>
+          <input
+            type="text"
+            value={editTitle}
+            onChange={(e) => setEditTitle(e.target.value)}
+            required
+            autoFocus
+            className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="block mb-2">
+          <span className="text-xs font-medium text-gray-500">
+            Description <span className="text-gray-400 font-normal">(optional)</span>
+          </span>
+          <textarea
+            value={editDescription}
+            onChange={(e) => setEditDescription(e.target.value)}
+            rows={2}
+            className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm resize-none"
+          />
+        </label>
+        <label className="block mb-3">
+          <span className="text-xs font-medium text-gray-500">
+            Due date <span className="text-gray-400 font-normal">(optional)</span>
+          </span>
+          <input
+            type="date"
+            value={editDueDate}
+            onChange={(e) => setEditDueDate(e.target.value)}
+            className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+          />
+        </label>
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            className="flex-1 bg-gray-900 text-white rounded px-3 py-1.5 text-sm font-medium hover:bg-gray-700 transition-colors duration-150"
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={() => setEditing(false)}
+            className="flex-1 border border-gray-300 bg-white text-gray-600 rounded px-3 py-1.5 text-sm hover:bg-gray-200 transition-colors duration-150"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 mb-2 flex items-start justify-between gap-3">
+      <div className="min-w-0">
+        <p className="text-gray-900 font-medium truncate">{task.title}</p>
+        {task.description && (
+          <p className="text-xs text-gray-500 mt-0.5">{task.description}</p>
+        )}
+        {task.dueDate && (
+          <p className="text-xs text-gray-400 mt-0.5">
+            Due {new Date(task.dueDate).toLocaleDateString()}
+          </p>
+        )}
+      </div>
+      <div className="flex items-center gap-1 shrink-0">
+        {task.status === "UPCOMING" && (
+          <button
+            onClick={handleComplete}
+            title="Mark complete"
+            className="text-green-600 hover:text-green-800 px-1.5 py-1 rounded hover:bg-green-50 transition-colors duration-150 text-base leading-none"
+          >
+            ✓
+          </button>
+        )}
+        <button
+          onClick={handleDelete}
+          title="Delete"
+          className="text-red-400 hover:text-red-600 px-1.5 py-1 rounded hover:bg-red-50 transition-colors duration-150 text-base leading-none"
+        >
+          ✕
+        </button>
+        <button
+          onClick={openEdit}
+          title="Edit"
+          className="text-gray-400 hover:text-gray-700 px-1.5 py-1 rounded hover:bg-gray-100 transition-colors duration-150 text-base leading-none tracking-tighter"
+        >
+          ···
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  tasks,
+  onRefresh,
+  onDeleted,
+  alwaysShow = false,
+}: {
+  title: string;
+  tasks: Task[];
+  onRefresh: () => Promise<void>;
+  onDeleted: (task: Task) => void;
+  alwaysShow?: boolean;
+}) {
+  if (tasks.length === 0 && !alwaysShow) return null;
   return (
     <div className="mb-8">
       <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
         {title}
       </h2>
-      {tasks.map((task) => (
-        <div
-          key={task.id}
-          className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 mb-2"
-        >
-          <p className="text-gray-900 font-medium">{task.title}</p>
-          {task.dueDate && (
-            <p className="text-xs text-gray-400 mt-1">
-              Due {new Date(task.dueDate).toLocaleDateString()}
-            </p>
-          )}
-        </div>
-      ))}
+      {tasks.length === 0 ? (
+        <p className="text-xs text-gray-300 italic">Nothing here yet.</p>
+      ) : (
+        tasks.map((task) => (
+          <TaskCard key={task.id} task={task} onRefresh={onRefresh} onDeleted={onDeleted} />
+        ))
+      )}
     </div>
   );
 }
 
 export default function TasksPage() {
   const [tasks, setTasks] = useState<Task[]>([]);
+  const [recentlyDeleted, setRecentlyDeleted] = useState<Task[]>([]);
   const [showForm, setShowForm] = useState(false);
   const [title, setTitle] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [error, setError] = useState<string | null>(null);
+
+  function handleDeleted(task: Task) {
+    setRecentlyDeleted((prev) => [task, ...prev].slice(0, 5));
+  }
+
+  async function handleRestore(task: Task) {
+    const res = await apiFetch("/api/v1/tasks", {
+      method: "POST",
+      body: JSON.stringify({
+        title: task.title,
+        description: task.description,
+        dueDate: task.dueDate ? task.dueDate.slice(0, 10) : undefined,
+      }),
+    });
+    if (res.ok) {
+      setRecentlyDeleted((prev) => prev.filter((t) => t.id !== task.id));
+      await fetchTasks();
+    }
+  }
 
   async function fetchTasks() {
     const res = await apiFetch("/api/v1/tasks");
@@ -111,7 +293,8 @@ export default function TasksPage() {
             </label>
             <label className="block mb-4">
               <span className="text-sm font-medium text-gray-700">
-                Due date <span className="text-gray-400 font-normal">(optional)</span>
+                Due date{" "}
+                <span className="text-gray-400 font-normal">(optional)</span>
               </span>
               <input
                 type="date"
@@ -130,14 +313,41 @@ export default function TasksPage() {
         )}
 
         <div className="w-full max-w-md">
-          <Section title="Overdue" tasks={overdue} />
-          <Section title="Upcoming" tasks={upcoming} />
-          <Section title="Completed" tasks={completed} />
+          <Section title="Overdue" tasks={overdue} onRefresh={fetchTasks} onDeleted={handleDeleted} />
+          <Section title="Upcoming" tasks={upcoming} onRefresh={fetchTasks} onDeleted={handleDeleted} />
+          <Section title="Completed" tasks={completed} onRefresh={fetchTasks} onDeleted={handleDeleted} alwaysShow />
           {tasks.length === 0 && !showForm && (
             <p className="text-sm text-gray-400 text-center">No tasks yet.</p>
           )}
         </div>
       </div>
+
+      {recentlyDeleted.length > 0 && (
+        <div className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-md bg-white border border-gray-200 rounded-t-xl shadow-lg px-4 pt-4 pb-6">
+          <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-3">
+            Recently Deleted
+          </h2>
+          {recentlyDeleted.map((task) => (
+            <div
+              key={task.id}
+              className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 mb-2"
+            >
+              <div className="min-w-0">
+                <p className="text-sm text-gray-400 truncate">{task.title}</p>
+                {task.description && (
+                  <p className="text-xs text-gray-300 truncate">{task.description}</p>
+                )}
+              </div>
+              <button
+                onClick={() => handleRestore(task)}
+                className="text-xs text-gray-500 border border-gray-300 bg-white rounded px-2 py-1 ml-3 shrink-0 hover:bg-gray-200 transition-colors duration-150"
+              >
+                Restore
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
     </Layout>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,6 +1,7 @@
 export type Task = {
   id: string;
   title: string;
+  description?: string | null;
   status: "UPCOMING" | "COMPLETED";
   dueDate?: string | null;
 };


### PR DESCRIPTION
## Summary
- Task cards with ✓ complete (green), ✕ delete (red), ··· edit (gray) icon buttons
- Inline edit form per card with title, description, and pre-filled due date
- Fixed-position recently deleted tray at bottom of screen — last 5 deleted tasks, one-click restore
- Added `description` field to Task model with migration
- Completed section always renders to prevent recently deleted tray filling the visual gap

## Test plan
- [x] ✓ marks a task complete and moves it to Completed section
- [x] ✕ deletes a task and it appears in the recently deleted tray at the bottom
- [x] ··· opens inline edit form pre-filled with existing values
- [x] Saving edit updates title, description, and/or due date
- [x] Restore re-creates the task and removes it from the tray
- [x] Recently deleted tray does not interfere with the Completed section

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)