### PR TITLE
feat(backend): add reminder CRUD endpoints

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import cors from "cors";
 import taskRouter from "./routes/tasks";
+import reminderRouter from "./routes/reminders";
 import authRouter from "./routes/auth";
 import { requireAuth } from "./middleware/auth";
 
@@ -14,6 +15,7 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/api/v1/tasks", requireAuth, taskRouter);
+app.use("/api/v1/reminders", requireAuth, reminderRouter);
 app.use("/api/v1/auth", authRouter);
 
 export default app;

--- a/backend/src/controllers/reminderController.ts
+++ b/backend/src/controllers/reminderController.ts
@@ -1,0 +1,75 @@
+import { Request, Response } from "express";
+import { RepeatFrequency, Status } from "@prisma/client";
+import {
+  getReminders,
+  getReminder,
+  createReminder,
+  updateReminder,
+  deleteReminder,
+} from "../services/reminderService";
+
+export async function getRemindersController(req: Request, res: Response) {
+  const data = await getReminders(req.userId!);
+  res.json({ success: true, data });
+}
+
+export async function getReminderController(req: Request, res: Response) {
+  try {
+    const data = await getReminder(req.params.id, req.userId!);
+    res.json({ success: true, data });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "NOT_FOUND") {
+      return res.status(404).json({ success: false, error: "Reminder not found" });
+    }
+    throw err;
+  }
+}
+
+export async function createReminderController(req: Request, res: Response) {
+  const { title, scheduledAt, repeatFrequency } = req.body;
+  if (!title || !scheduledAt) {
+    return res.status(400).json({ success: false, error: "Missing required fields" });
+  }
+  const data = await createReminder(
+    req.userId!,
+    title,
+    new Date(scheduledAt),
+    repeatFrequency as RepeatFrequency | undefined
+  );
+  res.status(201).json({ success: true, data });
+}
+
+export async function updateReminderController(req: Request, res: Response) {
+  try {
+    const { title, scheduledAt, repeatFrequency, status } = req.body;
+    const fields: {
+      title?: string;
+      scheduledAt?: Date;
+      repeatFrequency?: RepeatFrequency;
+      status?: Status;
+    } = {};
+    if (title !== undefined) fields.title = title;
+    if (scheduledAt !== undefined) fields.scheduledAt = new Date(scheduledAt);
+    if (repeatFrequency !== undefined) fields.repeatFrequency = repeatFrequency;
+    if (status !== undefined) fields.status = status;
+    const data = await updateReminder(req.params.id, req.userId!, fields);
+    res.json({ success: true, data });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "NOT_FOUND") {
+      return res.status(404).json({ success: false, error: "Reminder not found" });
+    }
+    throw err;
+  }
+}
+
+export async function deleteReminderController(req: Request, res: Response) {
+  try {
+    await deleteReminder(req.params.id, req.userId!);
+    res.status(204).send();
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "NOT_FOUND") {
+      return res.status(404).json({ success: false, error: "Reminder not found" });
+    }
+    throw err;
+  }
+}

--- a/backend/src/routes/reminders.ts
+++ b/backend/src/routes/reminders.ts
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import {
+  getRemindersController,
+  getReminderController,
+  createReminderController,
+  updateReminderController,
+  deleteReminderController,
+} from "../controllers/reminderController";
+
+const router = Router();
+
+router.get("/", getRemindersController);
+router.get("/:id", getReminderController);
+router.post("/", createReminderController);
+router.patch("/:id", updateReminderController);
+router.delete("/:id", deleteReminderController);
+
+export default router;

--- a/backend/src/services/reminderService.ts
+++ b/backend/src/services/reminderService.ts
@@ -1,0 +1,42 @@
+import { RepeatFrequency, Status } from "@prisma/client";
+import { prisma } from "../lib/prisma";
+
+export async function getReminders(userId: string) {
+  return prisma.reminder.findMany({ where: { userId } });
+}
+
+export async function getReminder(id: string, userId: string) {
+  const reminder = await prisma.reminder.findFirst({ where: { id, userId } });
+  if (!reminder) throw new Error("NOT_FOUND");
+  return reminder;
+}
+
+export async function createReminder(
+  userId: string,
+  title: string,
+  scheduledAt: Date,
+  repeatFrequency?: RepeatFrequency
+) {
+  return prisma.reminder.create({ data: { title, userId, scheduledAt, repeatFrequency } });
+}
+
+export async function updateReminder(
+  id: string,
+  userId: string,
+  fields: {
+    title?: string;
+    scheduledAt?: Date;
+    repeatFrequency?: RepeatFrequency;
+    status?: Status;
+  }
+) {
+  const reminder = await prisma.reminder.findFirst({ where: { id, userId } });
+  if (!reminder) throw new Error("NOT_FOUND");
+  return prisma.reminder.update({ where: { id }, data: fields });
+}
+
+export async function deleteReminder(id: string, userId: string) {
+  const reminder = await prisma.reminder.findFirst({ where: { id, userId } });
+  if (!reminder) throw new Error("NOT_FOUND");
+  await prisma.reminder.delete({ where: { id } });
+}


### PR DESCRIPTION
Implements full CRUD for reminders using the 3-layer pattern (route → controller → service), matching the existing task implementation.

- reminderService: getReminders, getReminder, createReminder, updateReminder, deleteReminder — all scoped to userId so a user can never read or mutate another user's reminders
- reminderController: validates required fields (title + scheduledAt) on create, returns 201 on create, 204 on delete, 404 when the reminder doesn't belong to the requesting user
- reminders router: maps POST /, GET /, GET /:id, PATCH /:id, DELETE /:id
- app.ts: registers /api/v1/reminders behind requireAuth middleware, consistent with how /api/v1/tasks is wired

Closes #74