### PR TITLE
feat(backend): add complete reminder endpoint with repeat logic

### DIFF
--- a/backend/src/controllers/reminderController.ts
+++ b/backend/src/controllers/reminderController.ts
@@ -6,6 +6,7 @@ import {
   createReminder,
   updateReminder,
   deleteReminder,
+  completeReminder,
 } from "../services/reminderService";
 
 export async function getRemindersController(req: Request, res: Response) {
@@ -66,6 +67,18 @@ export async function deleteReminderController(req: Request, res: Response) {
   try {
     await deleteReminder(req.params.id, req.userId!);
     res.status(204).send();
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "NOT_FOUND") {
+      return res.status(404).json({ success: false, error: "Reminder not found" });
+    }
+    throw err;
+  }
+}
+
+export async function completeReminderController(req: Request, res: Response) {
+  try {
+    await completeReminder(req.params.id, req.userId!);
+    res.json({ success: true });
   } catch (err: unknown) {
     if (err instanceof Error && err.message === "NOT_FOUND") {
       return res.status(404).json({ success: false, error: "Reminder not found" });

--- a/backend/src/routes/reminders.ts
+++ b/backend/src/routes/reminders.ts
@@ -5,6 +5,7 @@ import {
   createReminderController,
   updateReminderController,
   deleteReminderController,
+  completeReminderController,
 } from "../controllers/reminderController";
 
 const router = Router();
@@ -14,5 +15,6 @@ router.get("/:id", getReminderController);
 router.post("/", createReminderController);
 router.patch("/:id", updateReminderController);
 router.delete("/:id", deleteReminderController);
+router.patch("/:id/complete", completeReminderController);
 
 export default router;

--- a/backend/src/services/reminderService.ts
+++ b/backend/src/services/reminderService.ts
@@ -40,3 +40,24 @@ export async function deleteReminder(id: string, userId: string) {
   if (!reminder) throw new Error("NOT_FOUND");
   await prisma.reminder.delete({ where: { id } });
 }
+
+export async function completeReminder(id: string, userId: string) {
+  const reminder = await prisma.reminder.findFirst({ where: { id, userId } });
+  if (!reminder) throw new Error("NOT_FOUND");
+
+  await prisma.reminder.update({ where: { id }, data: { status: Status.COMPLETED } });
+
+  if (reminder.repeatFrequency === RepeatFrequency.DAILY) {
+    const next = new Date(reminder.scheduledAt);
+    next.setDate(next.getDate() + 1);
+    await prisma.reminder.create({
+      data: { title: reminder.title, userId, scheduledAt: next, repeatFrequency: RepeatFrequency.DAILY },
+    });
+  } else if (reminder.repeatFrequency === RepeatFrequency.WEEKLY) {
+    const next = new Date(reminder.scheduledAt);
+    next.setDate(next.getDate() + 7);
+    await prisma.reminder.create({
+      data: { title: reminder.title, userId, scheduledAt: next, repeatFrequency: RepeatFrequency.WEEKLY },
+    });
+  }
+}


### PR DESCRIPTION
Adds PATCH /api/v1/reminders/:id/complete behind the existing requireAuth middleware. The endpoint marks the target reminder as COMPLETED, then branches on repeatFrequency:

- NONE: no further action — reminder is archived
- DAILY: creates a new reminder with the same title and repeatFrequency, scheduledAt advanced by +1 day from the original scheduledAt
- WEEKLY: same as DAILY but advanced by +7 days

Returns 404 if the reminder doesn't exist or belongs to a different user, consistent with the rest of the reminders CRUD. The /complete route is registered after PATCH /:id in the router so the specific path takes precedence over the parameterised one.

Closes #75