### PR TITLE
feat(frontend): add Reminders page with create and list

### DIFF
--- a/backend/prisma/migrations/20260530063847_add_monthly_repeat_frequency/migration.sql
+++ b/backend/prisma/migrations/20260530063847_add_monthly_repeat_frequency/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "RepeatFrequency" ADD VALUE 'MONTHLY';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,6 +15,7 @@ enum RepeatFrequency {
   NONE
   DAILY
   WEEKLY
+  MONTHLY
 }
 
 model User {

--- a/backend/src/services/reminderService.ts
+++ b/backend/src/services/reminderService.ts
@@ -59,5 +59,11 @@ export async function completeReminder(id: string, userId: string) {
     await prisma.reminder.create({
       data: { title: reminder.title, userId, scheduledAt: next, repeatFrequency: RepeatFrequency.WEEKLY },
     });
+  } else if (reminder.repeatFrequency === RepeatFrequency.MONTHLY) {
+    const next = new Date(reminder.scheduledAt);
+    next.setMonth(next.getMonth() + 1);
+    await prisma.reminder.create({
+      data: { title: reminder.title, userId, scheduledAt: next, repeatFrequency: RepeatFrequency.MONTHLY },
+    });
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import SignupPage from "./pages/SignupPage";
 import LoginPage from "./pages/LoginPage";
 import TasksPage from "./pages/TasksPage";
+import RemindersPage from "./pages/RemindersPage";
 import Layout from "./components/Layout";
 
 export default function App() {
@@ -19,19 +20,30 @@ export default function App() {
   if (path === "/login") return <LoginPage />;
   if (!token) return null;
   if (path === "/tasks") return <TasksPage />;
+  if (path === "/reminders") return <RemindersPage />;
 
   return (
     <Layout>
-      <h1 className="text-5xl font-bold text-gray-900 text-center mt-12 mb-16">
-        Code Impact Training
-      </h1>
-      <div className="flex flex-col items-center gap-4">
-        <a
-          href="/tasks"
-          className="inline-block bg-gray-900 text-white text-base font-medium px-10 py-3 rounded hover:bg-gray-700 transition-colors duration-150"
-        >
-          Go to Tasks
-        </a>
+      <div className="flex flex-col items-center mt-8">
+        <div className="border border-gray-300 bg-white rounded-xl px-10 py-5 shadow-sm mb-12">
+          <h1 className="text-4xl font-bold text-gray-800 tracking-tight">
+            Code Impact Training
+          </h1>
+        </div>
+        <div className="flex flex-col items-center gap-3">
+          <a
+            href="/tasks"
+            className="w-52 text-center bg-slate-600 text-white text-sm font-medium px-6 py-3 rounded hover:bg-slate-500 transition-colors duration-150"
+          >
+            Go to Tasks
+          </a>
+          <a
+            href="/reminders"
+            className="w-52 text-center bg-slate-600 text-white text-sm font-medium px-6 py-3 rounded hover:bg-slate-500 transition-colors duration-150"
+          >
+            Go to Reminders
+          </a>
+        </div>
       </div>
     </Layout>
   );

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -7,7 +7,7 @@ function handleSignOut() {
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col p-8">
+    <div className="min-h-screen bg-gray-100 flex flex-col p-8">
       <div className="w-full flex justify-end mb-4">
         <button
           onClick={handleSignOut}

--- a/frontend/src/pages/RemindersPage.tsx
+++ b/frontend/src/pages/RemindersPage.tsx
@@ -1,0 +1,162 @@
+import { useState, useEffect } from "react";
+import type { FormEvent } from "react";
+import type { Reminder, RepeatFrequency } from "../types";
+import { apiFetch } from "../lib/api";
+import Layout from "../components/Layout";
+
+function ReminderCard({ reminder }: { reminder: Reminder }) {
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 mb-2">
+      <p className="text-gray-900 font-medium">{reminder.title}</p>
+      <p className="text-xs text-gray-400 mt-0.5">
+        {new Date(reminder.scheduledAt).toLocaleString()}
+      </p>
+      {reminder.repeatFrequency !== "NONE" && (
+        <p className="text-xs text-gray-400 mt-0.5">
+          Repeats {reminder.repeatFrequency.toLowerCase()}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function Section({
+  title,
+  reminders,
+  alwaysShow = false,
+}: {
+  title: string;
+  reminders: Reminder[];
+  alwaysShow?: boolean;
+}) {
+  if (reminders.length === 0 && !alwaysShow) return null;
+  return (
+    <div className="mb-8">
+      <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
+        {title}
+      </h2>
+      {reminders.length === 0 ? (
+        <p className="text-xs text-gray-300 italic">Nothing here yet.</p>
+      ) : (
+        reminders.map((reminder) => (
+          <ReminderCard key={reminder.id} reminder={reminder} />
+        ))
+      )}
+    </div>
+  );
+}
+
+export default function RemindersPage() {
+  const [reminders, setReminders] = useState<Reminder[]>([]);
+  const [showForm, setShowForm] = useState(false);
+  const [title, setTitle] = useState("");
+  const [scheduledAt, setScheduledAt] = useState("");
+  const [repeatFrequency, setRepeatFrequency] = useState<RepeatFrequency>("NONE");
+  const [error, setError] = useState<string | null>(null);
+
+  async function fetchReminders() {
+    const res = await apiFetch("/api/v1/reminders");
+    if (!res.ok) return;
+    const data = (await res.json()) as { data: Reminder[] };
+    setReminders(data.data);
+  }
+
+  useEffect(() => {
+    void fetchReminders();
+  }, []);
+
+  async function handleCreate(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const res = await apiFetch("/api/v1/reminders", {
+      method: "POST",
+      body: JSON.stringify({ title, scheduledAt, repeatFrequency }),
+    });
+    const data = (await res.json()) as { error?: string };
+    if (!res.ok) {
+      setError(data.error ?? "Failed to create reminder");
+      return;
+    }
+    setTitle("");
+    setScheduledAt("");
+    setRepeatFrequency("NONE");
+    setShowForm(false);
+    await fetchReminders();
+  }
+
+  const upcoming = reminders.filter((r) => r.status === "UPCOMING");
+  const completed = reminders.filter((r) => r.status === "COMPLETED");
+
+  return (
+    <Layout>
+      <div className="flex flex-col items-center">
+        <div className="w-full max-w-md flex justify-between items-center mb-8">
+          <h1 className="text-2xl font-bold text-gray-900">Reminders</h1>
+          <button
+            onClick={() => setShowForm((v) => !v)}
+            className="text-sm font-medium text-gray-600 border border-gray-300 bg-white px-4 py-2 rounded hover:bg-gray-200 transition-colors duration-150"
+          >
+            {showForm ? "Cancel" : "+ Add reminder"}
+          </button>
+        </div>
+
+        {showForm && (
+          <form
+            onSubmit={handleCreate}
+            className="bg-white rounded-lg shadow-sm border border-gray-200 p-5 w-full max-w-md mb-8"
+          >
+            {error && <p className="text-red-600 text-sm mb-3">{error}</p>}
+            <label className="block mb-3">
+              <span className="text-sm font-medium text-gray-700">Title</span>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                required
+                autoFocus
+                className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+              />
+            </label>
+            <label className="block mb-3">
+              <span className="text-sm font-medium text-gray-700">Scheduled at</span>
+              <input
+                type="datetime-local"
+                value={scheduledAt}
+                onChange={(e) => setScheduledAt(e.target.value)}
+                required
+                className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+              />
+            </label>
+            <label className="block mb-4">
+              <span className="text-sm font-medium text-gray-700">Repeat</span>
+              <select
+                value={repeatFrequency}
+                onChange={(e) => setRepeatFrequency(e.target.value as RepeatFrequency)}
+                className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+              >
+                <option value="NONE">None</option>
+                <option value="DAILY">Daily</option>
+                <option value="WEEKLY">Weekly</option>
+                <option value="MONTHLY">Monthly</option>
+              </select>
+            </label>
+            <button
+              type="submit"
+              className="w-full bg-gray-900 text-white rounded px-4 py-2 text-sm font-medium hover:bg-gray-700 transition-colors duration-150"
+            >
+              Save reminder
+            </button>
+          </form>
+        )}
+
+        <div className="w-full max-w-md">
+          <Section title="Upcoming" reminders={upcoming} alwaysShow />
+          <Section title="Completed" reminders={completed} />
+          {reminders.length === 0 && !showForm && (
+            <p className="text-sm text-gray-400 text-center">No reminders yet.</p>
+          )}
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/RemindersPage.tsx
+++ b/frontend/src/pages/RemindersPage.tsx
@@ -62,7 +62,13 @@ export default function RemindersPage() {
   }
 
   useEffect(() => {
-    void fetchReminders();
+    async function load() {
+      const res = await apiFetch("/api/v1/reminders");
+      if (!res.ok) return;
+      const data = (await res.json()) as { data: Reminder[] };
+      setReminders(data.data);
+    }
+    void load();
   }, []);
 
   async function handleCreate(e: FormEvent) {
@@ -142,7 +148,7 @@ export default function RemindersPage() {
             </label>
             <button
               type="submit"
-              className="w-full bg-gray-900 text-white rounded px-4 py-2 text-sm font-medium hover:bg-gray-700 transition-colors duration-150"
+              className="w-full bg-slate-600 text-white rounded px-4 py-2 text-sm font-medium hover:bg-slate-500 transition-colors duration-150"
             >
               Save reminder
             </button>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5,3 +5,13 @@ export type Task = {
   status: "UPCOMING" | "COMPLETED";
   dueDate?: string | null;
 };
+
+export type RepeatFrequency = "NONE" | "DAILY" | "WEEKLY" | "MONTHLY";
+
+export type Reminder = {
+  id: string;
+  title: string;
+  scheduledAt: string;
+  repeatFrequency: RepeatFrequency;
+  status: "UPCOMING" | "COMPLETED";
+};


### PR DESCRIPTION
Adds /reminders route with a full create-and-list UI, and extends the RepeatFrequency enum with a MONTHLY option across the stack.

Frontend:
- RemindersPage: fetches reminders on load and displays them in Upcoming/Completed sections; create form with title, datetime-local scheduledAt, and a repeat select (None/Daily/Weekly/Monthly)
- App.tsx: registers /reminders route and adds a "Go to Reminders" nav link on the home screen alongside the existing Tasks link
- types.ts: adds Reminder type and RepeatFrequency union including MONTHLY
- Home page polish: title moved higher with a white card/border treatment, nav buttons set to equal width (w-52) and restyled to slate-600, Layout background updated to bg-gray-100 for a softer feel — these tokens apply globally to all pages via Layout

Backend:
- Added MONTHLY to the RepeatFrequency enum in schema.prisma
- Migration 20260530063847_add_monthly_repeat_frequency applied
- Prisma client regenerated
- completeReminder service extended to handle MONTHLY by advancing scheduledAt by one calendar month (setMonth + 1)

Closes #76