### PR TITLE
feat(db): add Event model to Prisma schema

### DIFF
--- a/backend/prisma/migrations/20260530232504_add_event_model/migration.sql
+++ b/backend/prisma/migrations/20260530232504_add_event_model/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "Event" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "startAt" TIMESTAMP(3) NOT NULL,
+    "endAt" TIMESTAMP(3) NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Event_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Event" ADD CONSTRAINT "Event_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -27,6 +27,7 @@ model User {
   updatedAt DateTime @updatedAt
   tasks     Task[]
   reminders Reminder[]
+  events    Event[]
 }
 
 model Task {
@@ -51,4 +52,16 @@ model Reminder {
   user            User            @relation(fields: [userId], references: [id])
   createdAt       DateTime        @default(now())
   updatedAt       DateTime        @updatedAt
+}
+
+model Event {
+  id          String   @id @default(cuid())
+  title       String
+  description String?
+  startAt     DateTime
+  endAt       DateTime
+  userId      String
+  user        User     @relation(fields: [userId], references: [id])
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }


### PR DESCRIPTION
## Summary

- Adds `Event` model to `schema.prisma` with fields: `id`, `title`, `description` (optional), `startAt`, `endAt`, `userId` (FK → `User`), `createdAt`, `updatedAt`
- Adds `events Event[]` back-relation on the `User` model
- Migration `20260530232504_add_event_model` created and applied — creates the `Event` table with a primary key and a foreign key constraint on `userId` referencing `User(id)`

## Test plan

- [x] `prisma migrate dev` ran cleanly against local DB
- [x] `Event` table visible in DB with correct columns and FK constraint
- [x] Schema compiles without errors (no type warnings)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)