### PR TITLE
feat(backend): add event CRUD endpoints

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,6 +2,7 @@ import express from "express";
 import cors from "cors";
 import taskRouter from "./routes/tasks";
 import reminderRouter from "./routes/reminders";
+import eventRouter from "./routes/events";
 import authRouter from "./routes/auth";
 import { requireAuth } from "./middleware/auth";
 
@@ -16,6 +17,7 @@ app.get("/health", (_req, res) => {
 
 app.use("/api/v1/tasks", requireAuth, taskRouter);
 app.use("/api/v1/reminders", requireAuth, reminderRouter);
+app.use("/api/v1/events", requireAuth, eventRouter);
 app.use("/api/v1/auth", authRouter);
 
 export default app;

--- a/backend/src/controllers/eventController.ts
+++ b/backend/src/controllers/eventController.ts
@@ -1,0 +1,70 @@
+import { Request, Response } from "express";
+import {
+  getEvents,
+  getEvent,
+  createEvent,
+  updateEvent,
+  deleteEvent,
+} from "../services/eventService";
+
+export async function getEventsController(req: Request, res: Response) {
+  const data = await getEvents(req.userId!);
+  res.json({ success: true, data });
+}
+
+export async function getEventController(req: Request, res: Response) {
+  try {
+    const data = await getEvent(req.params.id, req.userId!);
+    res.json({ success: true, data });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "NOT_FOUND") {
+      return res.status(404).json({ success: false, error: "Event not found" });
+    }
+    throw err;
+  }
+}
+
+export async function createEventController(req: Request, res: Response) {
+  const { title, startAt, endAt, description } = req.body;
+  if (!title || !startAt || !endAt) {
+    return res.status(400).json({ success: false, error: "Missing required fields" });
+  }
+  const data = await createEvent(
+    req.userId!,
+    title,
+    new Date(startAt),
+    new Date(endAt),
+    description
+  );
+  res.status(201).json({ success: true, data });
+}
+
+export async function updateEventController(req: Request, res: Response) {
+  try {
+    const { title, description, startAt, endAt } = req.body;
+    const fields: { title?: string; description?: string; startAt?: Date; endAt?: Date } = {};
+    if (title !== undefined) fields.title = title;
+    if (description !== undefined) fields.description = description;
+    if (startAt !== undefined) fields.startAt = new Date(startAt);
+    if (endAt !== undefined) fields.endAt = new Date(endAt);
+    const data = await updateEvent(req.params.id, req.userId!, fields);
+    res.json({ success: true, data });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "NOT_FOUND") {
+      return res.status(404).json({ success: false, error: "Event not found" });
+    }
+    throw err;
+  }
+}
+
+export async function deleteEventController(req: Request, res: Response) {
+  try {
+    await deleteEvent(req.params.id, req.userId!);
+    res.status(204).send();
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "NOT_FOUND") {
+      return res.status(404).json({ success: false, error: "Event not found" });
+    }
+    throw err;
+  }
+}

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import {
+  getEventsController,
+  getEventController,
+  createEventController,
+  updateEventController,
+  deleteEventController,
+} from "../controllers/eventController";
+
+const router = Router();
+
+router.get("/", getEventsController);
+router.get("/:id", getEventController);
+router.post("/", createEventController);
+router.patch("/:id", updateEventController);
+router.delete("/:id", deleteEventController);
+
+export default router;

--- a/backend/src/services/eventService.ts
+++ b/backend/src/services/eventService.ts
@@ -1,0 +1,37 @@
+import { prisma } from "../lib/prisma";
+
+export async function getEvents(userId: string) {
+  return prisma.event.findMany({ where: { userId } });
+}
+
+export async function getEvent(id: string, userId: string) {
+  const event = await prisma.event.findFirst({ where: { id, userId } });
+  if (!event) throw new Error("NOT_FOUND");
+  return event;
+}
+
+export async function createEvent(
+  userId: string,
+  title: string,
+  startAt: Date,
+  endAt: Date,
+  description?: string
+) {
+  return prisma.event.create({ data: { title, userId, startAt, endAt, description } });
+}
+
+export async function updateEvent(
+  id: string,
+  userId: string,
+  fields: { title?: string; description?: string; startAt?: Date; endAt?: Date }
+) {
+  const event = await prisma.event.findFirst({ where: { id, userId } });
+  if (!event) throw new Error("NOT_FOUND");
+  return prisma.event.update({ where: { id }, data: fields });
+}
+
+export async function deleteEvent(id: string, userId: string) {
+  const event = await prisma.event.findFirst({ where: { id, userId } });
+  if (!event) throw new Error("NOT_FOUND");
+  await prisma.event.delete({ where: { id } });
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/events` — list all events for the authed user
- Adds `GET /api/v1/events/:id` — get a single event; 404 if not found or not owned by user
- Adds `POST /api/v1/events` — create an event with `title`, `startAt`, `endAt`, and optional `description`
- Adds `PATCH /api/v1/events/:id` — partial update; 404 if not owned by user
- Adds `DELETE /api/v1/events/:id` — delete; 404 if not owned by user; returns 204
- All routes sit behind `requireAuth` middleware and scope every query to `req.userId`
- Follows the existing route → controller → service 3-layer pattern

## Test plan

- [x] `POST /api/v1/events` creates an event scoped to the authed user
- [x] `GET /api/v1/events` returns only events belonging to the authed user
- [x] `GET /api/v1/events/:id` returns 404 for another user's event
- [x] `PATCH /api/v1/events/:id` returns 404 for another user's event
- [x] `DELETE /api/v1/events/:id` returns 404 for another user's event; 204 on success
- [x] All endpoints return 401 without a valid JWT

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)