### PR TITLE
feat(frontend): add Calendar page with month/week/day views

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import SignupPage from "./pages/SignupPage";
 import LoginPage from "./pages/LoginPage";
 import TasksPage from "./pages/TasksPage";
 import RemindersPage from "./pages/RemindersPage";
+import CalendarPage from "./pages/CalendarPage";
 import Layout from "./components/Layout";
 
 export default function App() {
@@ -21,6 +22,7 @@ export default function App() {
   if (!token) return null;
   if (path === "/tasks") return <TasksPage />;
   if (path === "/reminders") return <RemindersPage />;
+  if (path === "/calendar") return <CalendarPage />;
 
   return (
     <Layout>
@@ -42,6 +44,12 @@ export default function App() {
             className="w-52 text-center bg-slate-600 text-white text-sm font-medium px-6 py-3 rounded hover:bg-slate-500 transition-colors duration-150"
           >
             Go to Reminders
+          </a>
+          <a
+            href="/calendar"
+            className="w-52 text-center bg-slate-600 text-white text-sm font-medium px-6 py-3 rounded hover:bg-slate-500 transition-colors duration-150"
+          >
+            Go to Calendar
           </a>
         </div>
       </div>

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,0 +1,251 @@
+import { useState } from "react";
+import Layout from "../components/Layout";
+
+type View = "month" | "week" | "day";
+
+const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+function isSameDay(a: Date, b: Date) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function startOfWeek(date: Date) {
+  const d = new Date(date);
+  d.setDate(d.getDate() - d.getDay());
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function MonthView({ cursor, today }: { cursor: Date; today: Date }) {
+  const year = cursor.getFullYear();
+  const month = cursor.getMonth();
+
+  const firstDay = new Date(year, month, 1);
+  const startDay = new Date(firstDay);
+  startDay.setDate(startDay.getDate() - startDay.getDay());
+
+  const cells: Date[] = [];
+  const d = new Date(startDay);
+  while (cells.length < 42) {
+    cells.push(new Date(d));
+    d.setDate(d.getDate() + 1);
+  }
+
+  return (
+    <div className="flex-1">
+      <div className="grid grid-cols-7 border-l border-t border-gray-200">
+        {DAY_NAMES.map((name) => (
+          <div
+            key={name}
+            className="border-r border-b border-gray-200 py-2 text-center text-xs font-semibold text-gray-500 uppercase tracking-wide bg-gray-50"
+          >
+            {name}
+          </div>
+        ))}
+        {cells.map((cell, i) => {
+          const isToday = isSameDay(cell, today);
+          const isCurrentMonth = cell.getMonth() === month;
+          return (
+            <div
+              key={i}
+              className={`border-r border-b border-gray-200 min-h-[90px] p-2 ${
+                isCurrentMonth ? "bg-white" : "bg-gray-50"
+              }`}
+            >
+              <span
+                className={`inline-flex items-center justify-center w-7 h-7 rounded-full text-sm font-medium ${
+                  isToday
+                    ? "bg-slate-700 text-white"
+                    : isCurrentMonth
+                    ? "text-gray-800"
+                    : "text-gray-300"
+                }`}
+              >
+                {cell.getDate()}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function WeekView({ cursor, today }: { cursor: Date; today: Date }) {
+  const week = startOfWeek(cursor);
+  const days: Date[] = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(week);
+    d.setDate(d.getDate() + i);
+    return d;
+  });
+
+  return (
+    <div className="flex-1">
+      <div className="grid grid-cols-7 border-l border-t border-gray-200">
+        {days.map((day, i) => {
+          const isToday = isSameDay(day, today);
+          return (
+            <div key={i} className="border-r border-b border-gray-200 bg-gray-50 py-2 text-center">
+              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                {DAY_NAMES[day.getDay()]}
+              </p>
+              <span
+                className={`inline-flex items-center justify-center w-8 h-8 rounded-full text-sm font-medium mt-1 ${
+                  isToday ? "bg-slate-700 text-white" : "text-gray-800"
+                }`}
+              >
+                {day.getDate()}
+              </span>
+            </div>
+          );
+        })}
+        {days.map((day, i) => {
+          const isToday = isSameDay(day, today);
+          return (
+            <div
+              key={`body-${i}`}
+              className={`border-r border-b border-gray-200 min-h-[400px] p-2 ${
+                isToday ? "bg-slate-50" : "bg-white"
+              }`}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function DayView({ cursor, today }: { cursor: Date; today: Date }) {
+  const isToday = isSameDay(cursor, today);
+  return (
+    <div className="flex-1">
+      <div className="border border-gray-200 rounded-lg bg-white overflow-hidden">
+        <div className={`px-6 py-4 border-b border-gray-200 ${isToday ? "bg-slate-50" : "bg-gray-50"}`}>
+          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+            {DAY_NAMES[cursor.getDay()]}
+          </p>
+          <p className={`text-3xl font-bold mt-0.5 ${isToday ? "text-slate-700" : "text-gray-800"}`}>
+            {cursor.getDate()}
+          </p>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {MONTH_NAMES[cursor.getMonth()]} {cursor.getFullYear()}
+          </p>
+          {isToday && (
+            <span className="inline-block mt-2 text-xs font-medium bg-slate-700 text-white rounded-full px-2 py-0.5">
+              Today
+            </span>
+          )}
+        </div>
+        <div className="min-h-[400px] p-4" />
+      </div>
+    </div>
+  );
+}
+
+export default function CalendarPage() {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const [view, setView] = useState<View>("month");
+  const [cursor, setCursor] = useState(() => {
+    const d = new Date(today);
+    return d;
+  });
+
+  function navigate(dir: -1 | 1) {
+    setCursor((prev) => {
+      const d = new Date(prev);
+      if (view === "month") {
+        d.setMonth(d.getMonth() + dir);
+      } else if (view === "week") {
+        d.setDate(d.getDate() + dir * 7);
+      } else {
+        d.setDate(d.getDate() + dir);
+      }
+      return d;
+    });
+  }
+
+  function goToday() {
+    setCursor(new Date(today));
+  }
+
+  function headerLabel() {
+    if (view === "month") {
+      return `${MONTH_NAMES[cursor.getMonth()]} ${cursor.getFullYear()}`;
+    }
+    if (view === "week") {
+      const week = startOfWeek(cursor);
+      const end = new Date(week);
+      end.setDate(end.getDate() + 6);
+      const sameMonth = week.getMonth() === end.getMonth();
+      return sameMonth
+        ? `${MONTH_NAMES[week.getMonth()]} ${week.getDate()} – ${end.getDate()}, ${end.getFullYear()}`
+        : `${MONTH_NAMES[week.getMonth()]} ${week.getDate()} – ${MONTH_NAMES[end.getMonth()]} ${end.getDate()}, ${end.getFullYear()}`;
+    }
+    return `${MONTH_NAMES[cursor.getMonth()]} ${cursor.getDate()}, ${cursor.getFullYear()}`;
+  }
+
+  return (
+    <Layout>
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Calendar</h1>
+        <div className="flex items-center gap-2">
+          <div className="flex border border-gray-300 rounded overflow-hidden text-sm">
+            {(["month", "week", "day"] as View[]).map((v) => (
+              <button
+                key={v}
+                onClick={() => setView(v)}
+                className={`px-3 py-1.5 capitalize font-medium transition-colors duration-150 ${
+                  view === v
+                    ? "bg-slate-700 text-white"
+                    : "bg-white text-gray-600 hover:bg-gray-100"
+                }`}
+              >
+                {v}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3 mb-4">
+        <button
+          onClick={goToday}
+          className="text-sm font-medium text-gray-600 border border-gray-300 bg-white px-3 py-1.5 rounded hover:bg-gray-100 transition-colors duration-150"
+        >
+          Today
+        </button>
+        <div className="flex gap-1">
+          <button
+            onClick={() => navigate(-1)}
+            className="p-1.5 rounded hover:bg-gray-200 transition-colors duration-150 text-gray-600"
+            aria-label="Previous"
+          >
+            ‹
+          </button>
+          <button
+            onClick={() => navigate(1)}
+            className="p-1.5 rounded hover:bg-gray-200 transition-colors duration-150 text-gray-600"
+            aria-label="Next"
+          >
+            ›
+          </button>
+        </div>
+        <span className="text-base font-semibold text-gray-800">{headerLabel()}</span>
+      </div>
+
+      {view === "month" && <MonthView cursor={cursor} today={today} />}
+      {view === "week" && <WeekView cursor={cursor} today={today} />}
+      {view === "day" && <DayView cursor={cursor} today={today} />}
+    </Layout>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -15,3 +15,11 @@ export type Reminder = {
   repeatFrequency: RepeatFrequency;
   status: "UPCOMING" | "COMPLETED";
 };
+
+export type Event = {
+  id: string;
+  title: string;
+  description?: string | null;
+  startAt: string;
+  endAt: string;
+};


### PR DESCRIPTION
## Summary

- Adds `/calendar` route rendering a new `CalendarPage` component
- **Month view**: 7-column grid starting from Sunday; days outside the current month are dimmed; today gets a filled circle highlight
- **Week view**: header row with day names + dates, body columns for the week; today's column is tinted
- **Day view**: single-day card showing day name, date, month/year, and a "Today" badge when applicable
- Toggle between views with a segmented control; active view is highlighted
- Prev/next chevrons navigate by month / 7 days / 1 day depending on active view; "Today" button resets the cursor
- Adds `Event` type to `types.ts` (needed for upcoming issues #86/#87)
- Adds "Go to Calendar" link on the home page

## Test plan

- [x] `/calendar` renders without errors
- [x] Month/week/day toggle switches views correctly
- [x] Prev/next navigation works in all three views
- [x] Today is highlighted in each view
- [x] "Today" button resets cursor to current date
- [x] Home page shows "Go to Calendar" link

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)