### PR TITLE
feat(backend): add dashboard summary endpoint

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,6 +4,7 @@ import taskRouter from "./routes/tasks";
 import reminderRouter from "./routes/reminders";
 import eventRouter from "./routes/events";
 import authRouter from "./routes/auth";
+import dashboardRouter from "./routes/dashboard";
 import { requireAuth } from "./middleware/auth";
 
 const app = express();
@@ -18,6 +19,7 @@ app.get("/health", (_req, res) => {
 app.use("/api/v1/tasks", requireAuth, taskRouter);
 app.use("/api/v1/reminders", requireAuth, reminderRouter);
 app.use("/api/v1/events", requireAuth, eventRouter);
+app.use("/api/v1/dashboard", requireAuth, dashboardRouter);
 app.use("/api/v1/auth", authRouter);
 
 export default app;

--- a/backend/src/controllers/dashboardController.ts
+++ b/backend/src/controllers/dashboardController.ts
@@ -1,0 +1,7 @@
+import { Request, Response } from "express";
+import { getDashboardSummary } from "../services/dashboardService";
+
+export async function getDashboardController(req: Request, res: Response) {
+  const data = await getDashboardSummary(req.userId!);
+  res.json({ success: true, data });
+}

--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { getDashboardController } from "../controllers/dashboardController";
+
+const router = Router();
+
+router.get("/", getDashboardController);
+
+export default router;

--- a/backend/src/services/dashboardService.ts
+++ b/backend/src/services/dashboardService.ts
@@ -1,0 +1,24 @@
+import { prisma } from "../lib/prisma";
+
+export async function getDashboardSummary(userId: string) {
+  const now = new Date();
+  const todayStart = new Date(now);
+  todayStart.setUTCHours(0, 0, 0, 0);
+  const todayEnd = new Date(now);
+  todayEnd.setUTCHours(23, 59, 59, 999);
+
+  const [events, tasks, reminders] = await Promise.all([
+    prisma.event.findMany({
+      where: { userId, startAt: { gte: todayStart, lte: todayEnd } },
+      orderBy: { startAt: "asc" },
+    }),
+    prisma.task.findMany({
+      where: { userId, status: "UPCOMING", dueDate: { lte: todayEnd } },
+    }),
+    prisma.reminder.findMany({
+      where: { userId, status: "UPCOMING", scheduledAt: { gte: todayStart, lte: todayEnd } },
+    }),
+  ]);
+
+  return { events, tasks, reminders };
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/dashboard` behind JWT auth
- Returns today's events (sorted by `startAt`), overdue/due-today UPCOMING tasks, and UPCOMING reminders scheduled today
- Implemented via a single `Promise.all` query in `dashboardService.ts`

Closes #94