### PR TITLE
feat(backend): add AI briefing endpoint using Claude API

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.100.1",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
         "bcrypt": "^6.0.0",
@@ -33,6 +34,36 @@
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.0.0",
         "vitest": "^1.6.1"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.100.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
+      "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@electric-sql/pglite": {
@@ -1523,6 +1554,12 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -3319,6 +3356,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -3936,6 +3979,19 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -5398,6 +5454,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -5569,6 +5635,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.100.1",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "bcrypt": "^6.0.0",

--- a/backend/src/controllers/briefingController.ts
+++ b/backend/src/controllers/briefingController.ts
@@ -1,0 +1,10 @@
+import { Request, Response } from "express";
+import { generateBriefing } from "../services/briefingService";
+
+export async function getBriefingController(req: Request, res: Response) {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return res.status(503).json({ success: false, error: "AI briefing is not configured" });
+  }
+  const briefing = await generateBriefing(req.userId!);
+  res.json({ success: true, data: { briefing } });
+}

--- a/backend/src/routes/dashboard.ts
+++ b/backend/src/routes/dashboard.ts
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { getDashboardController } from "../controllers/dashboardController";
+import { getBriefingController } from "../controllers/briefingController";
 
 const router = Router();
 
 router.get("/", getDashboardController);
+router.post("/briefing", getBriefingController);
 
 export default router;

--- a/backend/src/services/briefingService.ts
+++ b/backend/src/services/briefingService.ts
@@ -1,0 +1,82 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { getDashboardSummary } from "./dashboardService";
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+export async function generateBriefing(userId: string): Promise<string> {
+  const { events, tasks, reminders } = await getDashboardSummary(userId);
+
+  const today = new Date().toLocaleDateString([], {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  const eventsText =
+    events.length === 0
+      ? "No events today."
+      : events
+          .map((e) => {
+            const start = new Date(e.startAt).toLocaleTimeString([], {
+              hour: "2-digit",
+              minute: "2-digit",
+            });
+            const end = new Date(e.endAt).toLocaleTimeString([], {
+              hour: "2-digit",
+              minute: "2-digit",
+            });
+            return `- ${e.title} (${start}–${end})${e.description ? `: ${e.description}` : ""}`;
+          })
+          .join("\n");
+
+  const tasksText =
+    tasks.length === 0
+      ? "No overdue or due-today tasks."
+      : tasks
+          .map((t) => {
+            const due = t.dueDate
+              ? ` (due ${new Date(t.dueDate).toLocaleDateString()})`
+              : "";
+            return `- ${t.title}${due}${t.description ? `: ${t.description}` : ""}`;
+          })
+          .join("\n");
+
+  const remindersText =
+    reminders.length === 0
+      ? "No reminders today."
+      : reminders
+          .map((r) => {
+            const time = new Date(r.scheduledAt).toLocaleTimeString([], {
+              hour: "2-digit",
+              minute: "2-digit",
+            });
+            return `- ${r.title} at ${time}`;
+          })
+          .join("\n");
+
+  const prompt = `Today is ${today}.
+
+Here is the user's schedule:
+
+EVENTS:
+${eventsText}
+
+TASKS DUE TODAY:
+${tasksText}
+
+REMINDERS:
+${remindersText}
+
+Write a concise, friendly daily briefing for the user based on the above. Keep it to 2-4 sentences. Focus on what's most important or time-sensitive.`;
+
+  const message = await client.messages.create({
+    model: "claude-haiku-4-5-20251001",
+    max_tokens: 256,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const block = message.content[0];
+  if (block.type !== "text") throw new Error("Unexpected response type from Claude");
+  return block.text;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     environment:
       DATABASE_URL: postgresql://postgres:password@db:5432/orbit
       JWT_SECRET: ${JWT_SECRET}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
     depends_on:
       - db
 


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/dashboard/briefing` behind JWT auth
- Fetches today's summary via `getDashboardSummary`, builds a prompt, and calls Claude Haiku
- Returns `{ "data": { "briefing": "..." } }` with a 2–4 sentence daily briefing
- `ANTHROPIC_API_KEY` read from env; returns 503 if not configured
- Adds `@anthropic-ai/sdk` dependency and wires `ANTHROPIC_API_KEY` into Docker Compose

Closes #95