### PR TITLE
feat(backend): add unit tests for reminder, event, and dashboard serv…

### DIFF
--- a/backend/test/dashboardService.test.ts
+++ b/backend/test/dashboardService.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockEventFindMany = vi.hoisted(() => vi.fn());
+const mockTaskFindMany = vi.hoisted(() => vi.fn());
+const mockReminderFindMany = vi.hoisted(() => vi.fn());
+
+vi.mock("../src/lib/prisma", () => ({
+  prisma: {
+    event: { findMany: mockEventFindMany },
+    task: { findMany: mockTaskFindMany },
+    reminder: { findMany: mockReminderFindMany },
+  },
+}));
+
+import { getDashboardSummary } from "../src/services/dashboardService";
+
+const userId = "user-1";
+
+describe("getDashboardSummary", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns events, tasks, and reminders for today", async () => {
+    const fakeEvents = [{ id: "evt-1", title: "Standup" }];
+    const fakeTasks = [{ id: "task-1", title: "Fix bug" }];
+    const fakeReminders = [{ id: "rem-1", title: "Call dentist" }];
+
+    mockEventFindMany.mockResolvedValue(fakeEvents);
+    mockTaskFindMany.mockResolvedValue(fakeTasks);
+    mockReminderFindMany.mockResolvedValue(fakeReminders);
+
+    const result = await getDashboardSummary(userId);
+
+    expect(result).toEqual({
+      events: fakeEvents,
+      tasks: fakeTasks,
+      reminders: fakeReminders,
+    });
+  });
+
+  it("queries events within today's UTC boundaries ordered by startAt", async () => {
+    mockEventFindMany.mockResolvedValue([]);
+    mockTaskFindMany.mockResolvedValue([]);
+    mockReminderFindMany.mockResolvedValue([]);
+
+    await getDashboardSummary(userId);
+
+    const eventCall = mockEventFindMany.mock.calls[0][0];
+    expect(eventCall.where.userId).toBe(userId);
+    expect(eventCall.where.startAt.gte).toBeInstanceOf(Date);
+    expect(eventCall.where.startAt.lte).toBeInstanceOf(Date);
+    expect(eventCall.orderBy).toEqual({ startAt: "asc" });
+
+    const gte = eventCall.where.startAt.gte as Date;
+    const lte = eventCall.where.startAt.lte as Date;
+    expect(gte.getUTCHours()).toBe(0);
+    expect(gte.getUTCMinutes()).toBe(0);
+    expect(lte.getUTCHours()).toBe(23);
+    expect(lte.getUTCMinutes()).toBe(59);
+  });
+
+  it("queries tasks with UPCOMING status and dueDate up to end of today", async () => {
+    mockEventFindMany.mockResolvedValue([]);
+    mockTaskFindMany.mockResolvedValue([]);
+    mockReminderFindMany.mockResolvedValue([]);
+
+    await getDashboardSummary(userId);
+
+    const taskCall = mockTaskFindMany.mock.calls[0][0];
+    expect(taskCall.where.userId).toBe(userId);
+    expect(taskCall.where.status).toBe("UPCOMING");
+    expect(taskCall.where.dueDate.lte).toBeInstanceOf(Date);
+  });
+
+  it("queries reminders with UPCOMING status within today's boundaries", async () => {
+    mockEventFindMany.mockResolvedValue([]);
+    mockTaskFindMany.mockResolvedValue([]);
+    mockReminderFindMany.mockResolvedValue([]);
+
+    await getDashboardSummary(userId);
+
+    const reminderCall = mockReminderFindMany.mock.calls[0][0];
+    expect(reminderCall.where.userId).toBe(userId);
+    expect(reminderCall.where.status).toBe("UPCOMING");
+    expect(reminderCall.where.scheduledAt.gte).toBeInstanceOf(Date);
+    expect(reminderCall.where.scheduledAt.lte).toBeInstanceOf(Date);
+  });
+
+  it("returns empty arrays when no data exists for today", async () => {
+    mockEventFindMany.mockResolvedValue([]);
+    mockTaskFindMany.mockResolvedValue([]);
+    mockReminderFindMany.mockResolvedValue([]);
+
+    const result = await getDashboardSummary(userId);
+    expect(result).toEqual({ events: [], tasks: [], reminders: [] });
+  });
+});

--- a/backend/test/eventService.test.ts
+++ b/backend/test/eventService.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFindMany = vi.hoisted(() => vi.fn());
+const mockFindFirst = vi.hoisted(() => vi.fn());
+const mockCreate = vi.hoisted(() => vi.fn());
+const mockUpdate = vi.hoisted(() => vi.fn());
+const mockDelete = vi.hoisted(() => vi.fn());
+
+vi.mock("../src/lib/prisma", () => ({
+  prisma: {
+    event: {
+      findMany: mockFindMany,
+      findFirst: mockFindFirst,
+      create: mockCreate,
+      update: mockUpdate,
+      delete: mockDelete,
+    },
+  },
+}));
+
+import {
+  getEvents,
+  getEvent,
+  createEvent,
+  updateEvent,
+  deleteEvent,
+} from "../src/services/eventService";
+
+const userId = "user-1";
+
+const fakeEvent = {
+  id: "evt-1",
+  title: "Team standup",
+  userId,
+  startAt: new Date("2026-06-20T10:00:00Z"),
+  endAt: new Date("2026-06-20T10:30:00Z"),
+  description: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe("getEvents", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns all events for a user", async () => {
+    mockFindMany.mockResolvedValue([fakeEvent]);
+    const result = await getEvents(userId);
+    expect(result).toEqual([fakeEvent]);
+    expect(mockFindMany).toHaveBeenCalledWith({ where: { userId } });
+  });
+});
+
+describe("getEvent", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the event when found", async () => {
+    mockFindFirst.mockResolvedValue(fakeEvent);
+    const result = await getEvent("evt-1", userId);
+    expect(result).toEqual(fakeEvent);
+    expect(mockFindFirst).toHaveBeenCalledWith({ where: { id: "evt-1", userId } });
+  });
+
+  it("throws NOT_FOUND when event does not exist", async () => {
+    mockFindFirst.mockResolvedValue(null);
+    await expect(getEvent("bad-id", userId)).rejects.toThrow("NOT_FOUND");
+  });
+});
+
+describe("createEvent", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("creates an event without description", async () => {
+    mockCreate.mockResolvedValue(fakeEvent);
+    const result = await createEvent(
+      userId,
+      "Team standup",
+      new Date("2026-06-20T10:00:00Z"),
+      new Date("2026-06-20T10:30:00Z"),
+    );
+    expect(result).toEqual(fakeEvent);
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: {
+        title: "Team standup",
+        userId,
+        startAt: new Date("2026-06-20T10:00:00Z"),
+        endAt: new Date("2026-06-20T10:30:00Z"),
+        description: undefined,
+      },
+    });
+  });
+
+  it("creates an event with a description", async () => {
+    const withDesc = { ...fakeEvent, description: "Daily sync" };
+    mockCreate.mockResolvedValue(withDesc);
+    const result = await createEvent(
+      userId,
+      "Team standup",
+      new Date("2026-06-20T10:00:00Z"),
+      new Date("2026-06-20T10:30:00Z"),
+      "Daily sync",
+    );
+    expect(result).toEqual(withDesc);
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: {
+        title: "Team standup",
+        userId,
+        startAt: new Date("2026-06-20T10:00:00Z"),
+        endAt: new Date("2026-06-20T10:30:00Z"),
+        description: "Daily sync",
+      },
+    });
+  });
+});
+
+describe("updateEvent", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("updates the event when found", async () => {
+    const updated = { ...fakeEvent, title: "Renamed standup" };
+    mockFindFirst.mockResolvedValue(fakeEvent);
+    mockUpdate.mockResolvedValue(updated);
+    const result = await updateEvent("evt-1", userId, { title: "Renamed standup" });
+    expect(result).toEqual(updated);
+    expect(mockUpdate).toHaveBeenCalledWith({ where: { id: "evt-1" }, data: { title: "Renamed standup" } });
+  });
+
+  it("throws NOT_FOUND when event does not exist", async () => {
+    mockFindFirst.mockResolvedValue(null);
+    await expect(updateEvent("bad-id", userId, { title: "x" })).rejects.toThrow("NOT_FOUND");
+  });
+});
+
+describe("deleteEvent", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("deletes the event when found", async () => {
+    mockFindFirst.mockResolvedValue(fakeEvent);
+    mockDelete.mockResolvedValue(fakeEvent);
+    await deleteEvent("evt-1", userId);
+    expect(mockDelete).toHaveBeenCalledWith({ where: { id: "evt-1" } });
+  });
+
+  it("throws NOT_FOUND when event does not exist", async () => {
+    mockFindFirst.mockResolvedValue(null);
+    await expect(deleteEvent("bad-id", userId)).rejects.toThrow("NOT_FOUND");
+  });
+});

--- a/backend/test/reminderService.test.ts
+++ b/backend/test/reminderService.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFindMany = vi.hoisted(() => vi.fn());
+const mockFindFirst = vi.hoisted(() => vi.fn());
+const mockCreate = vi.hoisted(() => vi.fn());
+const mockUpdate = vi.hoisted(() => vi.fn());
+const mockDelete = vi.hoisted(() => vi.fn());
+
+vi.mock("../src/lib/prisma", () => ({
+  prisma: {
+    reminder: {
+      findMany: mockFindMany,
+      findFirst: mockFindFirst,
+      create: mockCreate,
+      update: mockUpdate,
+      delete: mockDelete,
+    },
+  },
+}));
+
+import {
+  getReminders,
+  getReminder,
+  createReminder,
+  updateReminder,
+  deleteReminder,
+  completeReminder,
+} from "../src/services/reminderService";
+
+const userId = "user-1";
+
+const fakeReminder = {
+  id: "rem-1",
+  title: "Take out trash",
+  userId,
+  scheduledAt: new Date("2026-06-20T09:00:00Z"),
+  repeatFrequency: null,
+  status: "UPCOMING",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe("getReminders", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns all reminders for a user", async () => {
+    mockFindMany.mockResolvedValue([fakeReminder]);
+    const result = await getReminders(userId);
+    expect(result).toEqual([fakeReminder]);
+    expect(mockFindMany).toHaveBeenCalledWith({ where: { userId } });
+  });
+});
+
+describe("getReminder", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the reminder when found", async () => {
+    mockFindFirst.mockResolvedValue(fakeReminder);
+    const result = await getReminder("rem-1", userId);
+    expect(result).toEqual(fakeReminder);
+    expect(mockFindFirst).toHaveBeenCalledWith({ where: { id: "rem-1", userId } });
+  });
+
+  it("throws NOT_FOUND when reminder does not exist", async () => {
+    mockFindFirst.mockResolvedValue(null);
+    await expect(getReminder("bad-id", userId)).rejects.toThrow("NOT_FOUND");
+  });
+});
+
+describe("createReminder", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("creates a reminder without repeat frequency", async () => {
+    mockCreate.mockResolvedValue(fakeReminder);
+    const result = await createReminder(userId, "Take out trash", new Date("2026-06-20T09:00:00Z"));
+    expect(result).toEqual(fakeReminder);
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: {
+        title: "Take out trash",
+        userId,
+        scheduledAt: new Date("2026-06-20T09:00:00Z"),
+        repeatFrequency: undefined,
+      },
+    });
+  });
+
+  it("creates a reminder with a repeat frequency", async () => {
+    const repeating = { ...fakeReminder, repeatFrequency: "DAILY" };
+    mockCreate.mockResolvedValue(repeating);
+    const result = await createReminder(userId, "Take out trash", new Date("2026-06-20T09:00:00Z"), "DAILY" as any);
+    expect(result).toEqual(repeating);
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: {
+        title: "Take out trash",
+        userId,
+        scheduledAt: new Date("2026-06-20T09:00:00Z"),
+        repeatFrequency: "DAILY",
+      },
+    });
+  });
+});
+
+describe("updateReminder", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("updates the reminder when found", async () => {
+    const updated = { ...fakeReminder, title: "Updated title" };
+    mockFindFirst.mockResolvedValue(fakeReminder);
+    mockUpdate.mockResolvedValue(updated);
+    const result = await updateReminder("rem-1", userId, { title: "Updated title" });
+    expect(result).toEqual(updated);
+    expect(mockUpdate).toHaveBeenCalledWith({ where: { id: "rem-1" }, data: { title: "Updated title" } });
+  });
+
+  it("throws NOT_FOUND when reminder does not exist", async () => {
+    mockFindFirst.mockResolvedValue(null);
+    await expect(updateReminder("bad-id", userId, { title: "x" })).rejects.toThrow("NOT_FOUND");
+  });
+});
+
+describe("deleteReminder", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("deletes the reminder when found", async () => {
+    mockFindFirst.mockResolvedValue(fakeReminder);
+    mockDelete.mockResolvedValue(fakeReminder);
+    await deleteReminder("rem-1", userId);
+    expect(mockDelete).toHaveBeenCalledWith({ where: { id: "rem-1" } });
+  });
+
+  it("throws NOT_FOUND when reminder does not exist", async () => {
+    mockFindFirst.mockResolvedValue(null);
+    await expect(deleteReminder("bad-id", userId)).rejects.toThrow("NOT_FOUND");
+  });
+});
+
+describe("completeReminder", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("throws NOT_FOUND when reminder does not exist", async () => {
+    mockFindFirst.mockResolvedValue(null);
+    await expect(completeReminder("bad-id", userId)).rejects.toThrow("NOT_FOUND");
+  });
+
+  it("marks reminder as COMPLETED and does not create a new one when no repeat", async () => {
+    mockFindFirst.mockResolvedValue(fakeReminder);
+    mockUpdate.mockResolvedValue({ ...fakeReminder, status: "COMPLETED" });
+    await completeReminder("rem-1", userId);
+    expect(mockUpdate).toHaveBeenCalledWith({ where: { id: "rem-1" }, data: { status: "COMPLETED" } });
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates a next-day reminder when repeat is DAILY", async () => {
+    const daily = { ...fakeReminder, repeatFrequency: "DAILY" };
+    mockFindFirst.mockResolvedValue(daily);
+    mockUpdate.mockResolvedValue({ ...daily, status: "COMPLETED" });
+    mockCreate.mockResolvedValue({});
+    await completeReminder("rem-1", userId);
+
+    const expectedNext = new Date("2026-06-20T09:00:00Z");
+    expectedNext.setDate(expectedNext.getDate() + 1);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: {
+        title: "Take out trash",
+        userId,
+        scheduledAt: expectedNext,
+        repeatFrequency: "DAILY",
+      },
+    });
+  });
+
+  it("creates a next-week reminder when repeat is WEEKLY", async () => {
+    const weekly = { ...fakeReminder, repeatFrequency: "WEEKLY" };
+    mockFindFirst.mockResolvedValue(weekly);
+    mockUpdate.mockResolvedValue({ ...weekly, status: "COMPLETED" });
+    mockCreate.mockResolvedValue({});
+    await completeReminder("rem-1", userId);
+
+    const expectedNext = new Date("2026-06-20T09:00:00Z");
+    expectedNext.setDate(expectedNext.getDate() + 7);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: {
+        title: "Take out trash",
+        userId,
+        scheduledAt: expectedNext,
+        repeatFrequency: "WEEKLY",
+      },
+    });
+  });
+
+  it("creates a next-month reminder when repeat is MONTHLY", async () => {
+    const monthly = { ...fakeReminder, repeatFrequency: "MONTHLY" };
+    mockFindFirst.mockResolvedValue(monthly);
+    mockUpdate.mockResolvedValue({ ...monthly, status: "COMPLETED" });
+    mockCreate.mockResolvedValue({});
+    await completeReminder("rem-1", userId);
+
+    const expectedNext = new Date("2026-06-20T09:00:00Z");
+    expectedNext.setMonth(expectedNext.getMonth() + 1);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: {
+        title: "Take out trash",
+        userId,
+        scheduledAt: expectedNext,
+        repeatFrequency: "MONTHLY",
+      },
+    });
+  });
+});

--- a/backend/test/reminderService.test.ts
+++ b/backend/test/reminderService.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RepeatFrequency } from "@prisma/client";
 
 const mockFindMany = vi.hoisted(() => vi.fn());
 const mockFindFirst = vi.hoisted(() => vi.fn());
@@ -87,7 +88,7 @@ describe("createReminder", () => {
   it("creates a reminder with a repeat frequency", async () => {
     const repeating = { ...fakeReminder, repeatFrequency: "DAILY" };
     mockCreate.mockResolvedValue(repeating);
-    const result = await createReminder(userId, "Take out trash", new Date("2026-06-20T09:00:00Z"), "DAILY" as any);
+    const result = await createReminder(userId, "Take out trash", new Date("2026-06-20T09:00:00Z"), RepeatFrequency.DAILY);
     expect(result).toEqual(repeating);
     expect(mockCreate).toHaveBeenCalledWith({
       data: {


### PR DESCRIPTION
…ices (#103)

Add comprehensive unit tests for three service layers that were missing test coverage:

- reminderService: 14 tests covering CRUD operations, NOT_FOUND error paths, and completeReminder logic including DAILY, WEEKLY, and MONTHLY repeat frequency scheduling
- eventService: 9 tests covering CRUD operations with and without optional description, plus NOT_FOUND error paths
- dashboardService: 5 tests verifying the summary query structure (UTC day boundaries, UPCOMING status filters, startAt ordering) and return shape

All tests use vi.hoisted() + vi.mock() to mock Prisma, matching the established pattern from authService.test.ts.