### PR TITLE
feat(backend): add profile endpoints (#107)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+backend/uploads/*
+!backend/uploads/.gitkeep

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
         "dotenv": "^17.4.2",
         "express": "^4.22.1",
         "jsonwebtoken": "^9.0.3",
+        "multer": "^2.2.0",
         "pg": "^8.20.0"
       },
       "devDependencies": {
@@ -24,6 +25,7 @@
         "@types/cors": "^2.8.19",
         "@types/express": "^4.17.25",
         "@types/jsonwebtoken": "^9.0.10",
+        "@types/multer": "^2.1.0",
         "@types/node": "^20.19.39",
         "@types/pg": "^8.20.0",
         "@types/supertest": "^6.0.2",
@@ -1696,6 +1698,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -2265,6 +2277,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2395,6 +2413,23 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2636,6 +2671,21 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/confbox": {
       "version": "0.1.8",
@@ -4327,6 +4377,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/mysql2": {
       "version": "3.15.3",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
@@ -5082,6 +5151,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
@@ -5480,6 +5563,23 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
@@ -5711,6 +5811,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -5780,6 +5886,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "dotenv": "^17.4.2",
     "express": "^4.22.1",
     "jsonwebtoken": "^9.0.3",
+    "multer": "^2.2.0",
     "pg": "^8.20.0"
   },
   "devDependencies": {
@@ -28,6 +29,7 @@
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.25",
     "@types/jsonwebtoken": "^9.0.10",
+    "@types/multer": "^2.1.0",
     "@types/node": "^20.19.39",
     "@types/pg": "^8.20.0",
     "@types/supertest": "^6.0.2",

--- a/backend/prisma/migrations/20260617042929_add_profile_picture/migration.sql
+++ b/backend/prisma/migrations/20260617042929_add_profile_picture/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "profilePicture" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,15 +19,16 @@ enum RepeatFrequency {
 }
 
 model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  passwordHash String
-  displayName String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  tasks     Task[]
-  reminders Reminder[]
-  events    Event[]
+  id             String   @id @default(cuid())
+  email          String   @unique
+  passwordHash   String
+  displayName    String
+  profilePicture String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  tasks          Task[]
+  reminders      Reminder[]
+  events         Event[]
 }
 
 model Task {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,16 +1,19 @@
 import express from "express";
 import cors from "cors";
+import path from "path";
 import taskRouter from "./routes/tasks";
 import reminderRouter from "./routes/reminders";
 import eventRouter from "./routes/events";
 import authRouter from "./routes/auth";
 import dashboardRouter from "./routes/dashboard";
+import profileRouter from "./routes/profile";
 import { requireAuth } from "./middleware/auth";
 
 const app = express();
 
 app.use(cors({ origin: process.env.CORS_ORIGIN }));
 app.use(express.json());
+app.use("/uploads", express.static(path.join(__dirname, "../uploads")));
 
 app.get("/health", (_req, res) => {
   res.status(200).json({ status: "ok" });
@@ -20,6 +23,7 @@ app.use("/api/v1/tasks", requireAuth, taskRouter);
 app.use("/api/v1/reminders", requireAuth, reminderRouter);
 app.use("/api/v1/events", requireAuth, eventRouter);
 app.use("/api/v1/dashboard", requireAuth, dashboardRouter);
+app.use("/api/v1/profile", requireAuth, profileRouter);
 app.use("/api/v1/auth", authRouter);
 
 export default app;

--- a/backend/src/controllers/profileController.ts
+++ b/backend/src/controllers/profileController.ts
@@ -1,0 +1,36 @@
+import { Request, Response } from "express";
+import { getProfile, updateProfile } from "../services/profileService";
+
+export async function getProfileController(req: Request, res: Response) {
+  try {
+    const data = await getProfile(req.userId!);
+    res.json({ success: true, data });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "NOT_FOUND") {
+      return res.status(404).json({ success: false, error: "Profile not found" });
+    }
+    throw err;
+  }
+}
+
+export async function updateProfileController(req: Request, res: Response) {
+  try {
+    const fields: { displayName?: string; profilePicture?: string } = {};
+
+    if (req.body.displayName !== undefined) {
+      fields.displayName = req.body.displayName;
+    }
+
+    if (req.file) {
+      fields.profilePicture = `/uploads/${req.file.filename}`;
+    }
+
+    const data = await updateProfile(req.userId!, fields);
+    res.json({ success: true, data });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "NOT_FOUND") {
+      return res.status(404).json({ success: false, error: "Profile not found" });
+    }
+    throw err;
+  }
+}

--- a/backend/src/routes/profile.ts
+++ b/backend/src/routes/profile.ts
@@ -1,0 +1,37 @@
+import { Router } from "express";
+import multer from "multer";
+import path from "path";
+import {
+  getProfileController,
+  updateProfileController,
+} from "../controllers/profileController";
+
+const storage = multer.diskStorage({
+  destination: path.join(__dirname, "../../uploads"),
+  filename: (_req, file, cb) => {
+    const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+    const ext = path.extname(file.originalname);
+    cb(null, `${uniqueSuffix}${ext}`);
+  },
+});
+
+const upload = multer({
+  storage,
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    const allowed = [".jpg", ".jpeg", ".png", ".webp"];
+    const ext = path.extname(file.originalname).toLowerCase();
+    if (allowed.includes(ext)) {
+      cb(null, true);
+    } else {
+      cb(new Error("Only .jpg, .jpeg, .png, and .webp files are allowed"));
+    }
+  },
+});
+
+const router = Router();
+
+router.get("/", getProfileController);
+router.patch("/", upload.single("profilePicture"), updateProfileController);
+
+export default router;

--- a/backend/src/services/profileService.ts
+++ b/backend/src/services/profileService.ts
@@ -1,0 +1,32 @@
+import { prisma } from "../lib/prisma";
+
+const profileSelect = {
+  id: true,
+  email: true,
+  displayName: true,
+  profilePicture: true,
+  createdAt: true,
+  updatedAt: true,
+};
+
+export async function getProfile(userId: string) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: profileSelect,
+  });
+  if (!user) throw new Error("NOT_FOUND");
+  return user;
+}
+
+export async function updateProfile(
+  userId: string,
+  fields: { displayName?: string; profilePicture?: string }
+) {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new Error("NOT_FOUND");
+  return prisma.user.update({
+    where: { id: userId },
+    data: fields,
+    select: profileSelect,
+  });
+}


### PR DESCRIPTION
Add GET and PATCH endpoints for the authenticated user's profile at /api/v1/profile, following the route → controller → service pattern.

- GET /api/v1/profile returns displayName, email, profilePicture URL
- PATCH /api/v1/profile updates displayName (JSON body) and/or profilePicture (multipart file upload via multer)
- Added profilePicture (String?) field to User model with migration
- Multer configured with disk storage in backend/uploads/, 5MB limit, restricted to .jpg/.jpeg/.png/.webp
- Uploaded files served as static assets at /uploads/<filename>
- uploads/ directory gitignored (except .gitkeep)
- Installed multer 2.2.0 and @types/multer 2.1.0