### PR TITLE
feat(backend): add weather integration to AI briefing (#109)

### DIFF
--- a/backend/src/controllers/briefingController.ts
+++ b/backend/src/controllers/briefingController.ts
@@ -5,6 +5,15 @@ export async function getBriefingController(req: Request, res: Response) {
   if (!process.env.ANTHROPIC_API_KEY) {
     return res.status(503).json({ success: false, error: "AI briefing is not configured" });
   }
-  const briefing = await generateBriefing(req.userId!);
+
+  const { lat, lon, localTime, timezone } = req.body as {
+    lat?: number;
+    lon?: number;
+    localTime?: string;
+    timezone?: string;
+  };
+  const coords = typeof lat === "number" && typeof lon === "number" ? { lat, lon } : undefined;
+
+  const briefing = await generateBriefing(req.userId!, coords, { localTime, timezone });
   res.json({ success: true, data: { briefing } });
 }

--- a/backend/src/controllers/dashboardController.ts
+++ b/backend/src/controllers/dashboardController.ts
@@ -2,6 +2,10 @@ import { Request, Response } from "express";
 import { getDashboardSummary } from "../services/dashboardService";
 
 export async function getDashboardController(req: Request, res: Response) {
-  const data = await getDashboardSummary(req.userId!);
+  const lat = parseFloat(req.query.lat as string);
+  const lon = parseFloat(req.query.lon as string);
+  const coords = !isNaN(lat) && !isNaN(lon) ? { lat, lon } : undefined;
+
+  const data = await getDashboardSummary(req.userId!, coords);
   res.json({ success: true, data });
 }

--- a/backend/src/routes/profile.ts
+++ b/backend/src/routes/profile.ts
@@ -1,13 +1,17 @@
 import { Router } from "express";
 import multer from "multer";
 import path from "path";
+import fs from "fs";
 import {
   getProfileController,
   updateProfileController,
 } from "../controllers/profileController";
 
+const uploadsDir = path.join(__dirname, "../../uploads");
+fs.mkdirSync(uploadsDir, { recursive: true });
+
 const storage = multer.diskStorage({
-  destination: path.join(__dirname, "../../uploads"),
+  destination: uploadsDir,
   filename: (_req, file, cb) => {
     const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
     const ext = path.extname(file.originalname);

--- a/backend/src/services/briefingService.ts
+++ b/backend/src/services/briefingService.ts
@@ -3,15 +3,27 @@ import { getDashboardSummary } from "./dashboardService";
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
-export async function generateBriefing(userId: string): Promise<string> {
-  const { events, tasks, reminders } = await getDashboardSummary(userId);
+export async function generateBriefing(
+  userId: string,
+  coords?: { lat: number; lon: number },
+  timeContext?: { localTime?: string; timezone?: string }
+): Promise<string> {
+  const { events, tasks, reminders, weather } = await getDashboardSummary(userId, coords);
 
-  const today = new Date().toLocaleDateString([], {
+  const now = new Date();
+  const today = now.toLocaleDateString([], {
     weekday: "long",
     year: "numeric",
     month: "long",
     day: "numeric",
   });
+
+  const currentTime = timeContext?.localTime ?? now.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: true,
+  });
+  const tz = timeContext?.timezone ?? "unknown timezone";
 
   const eventsText =
     events.length === 0
@@ -55,8 +67,12 @@ export async function generateBriefing(userId: string): Promise<string> {
           })
           .join("\n");
 
-  const prompt = `Today is ${today}.
+  const weatherText = weather
+    ? `Current conditions as of right now: ${weather.temperature}°F, ${weather.condition}.`
+    : null;
 
+  const prompt = `Today is ${today}. The current time is ${currentTime} (${tz}).
+${weatherText ? `\nWEATHER:\n${weatherText}\n` : ""}
 Here is the user's schedule:
 
 EVENTS:
@@ -68,7 +84,7 @@ ${tasksText}
 REMINDERS:
 ${remindersText}
 
-Write a concise, friendly daily briefing for the user based on the above. Keep it to 2-4 sentences. Focus on what's most important or time-sensitive.`;
+Write a concise, friendly daily briefing for the user based on the above. Keep it to 2-4 sentences. Use a greeting appropriate to the current time of day (morning/afternoon/evening/night). Focus on what's most important or time-sensitive.${weatherText ? " Mention the current weather conditions briefly — do not speculate about what the weather will be like later." : ""}`;
 
   const message = await client.messages.create({
     model: "claude-haiku-4-5-20251001",

--- a/backend/src/services/dashboardService.ts
+++ b/backend/src/services/dashboardService.ts
@@ -1,13 +1,14 @@
 import { prisma } from "../lib/prisma";
+import { getWeather } from "./weatherService";
 
-export async function getDashboardSummary(userId: string) {
+export async function getDashboardSummary(userId: string, coords?: { lat: number; lon: number }) {
   const now = new Date();
   const todayStart = new Date(now);
   todayStart.setUTCHours(0, 0, 0, 0);
   const todayEnd = new Date(now);
   todayEnd.setUTCHours(23, 59, 59, 999);
 
-  const [events, tasks, reminders] = await Promise.all([
+  const [events, tasks, reminders, weather] = await Promise.all([
     prisma.event.findMany({
       where: { userId, startAt: { gte: todayStart, lte: todayEnd } },
       orderBy: { startAt: "asc" },
@@ -18,7 +19,8 @@ export async function getDashboardSummary(userId: string) {
     prisma.reminder.findMany({
       where: { userId, status: "UPCOMING", scheduledAt: { gte: todayStart, lte: todayEnd } },
     }),
+    coords ? getWeather(coords.lat, coords.lon) : Promise.resolve(null),
   ]);
 
-  return { events, tasks, reminders };
+  return { events, tasks, reminders, weather };
 }

--- a/backend/src/services/weatherService.ts
+++ b/backend/src/services/weatherService.ts
@@ -1,0 +1,46 @@
+export type Weather = {
+  temperature: number;
+  condition: string;
+};
+
+const WMO_DESCRIPTIONS: Record<number, string> = {
+  0: "clear sky",
+  1: "mainly clear",
+  2: "partly cloudy",
+  3: "overcast",
+  45: "foggy",
+  48: "depositing rime fog",
+  51: "light drizzle",
+  53: "moderate drizzle",
+  55: "dense drizzle",
+  61: "slight rain",
+  63: "moderate rain",
+  65: "heavy rain",
+  71: "slight snow",
+  73: "moderate snow",
+  75: "heavy snow",
+  77: "snow grains",
+  80: "slight rain showers",
+  81: "moderate rain showers",
+  82: "violent rain showers",
+  85: "slight snow showers",
+  86: "heavy snow showers",
+  95: "thunderstorm",
+  96: "thunderstorm with slight hail",
+  99: "thunderstorm with heavy hail",
+};
+
+export async function getWeather(lat: number, lon: number): Promise<Weather | null> {
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,weather_code&temperature_unit=fahrenheit`;
+  const res = await fetch(url);
+  if (!res.ok) return null;
+
+  const data = (await res.json()) as {
+    current: { temperature_2m: number; weather_code: number };
+  };
+
+  return {
+    temperature: Math.round(data.current.temperature_2m),
+    condition: WMO_DESCRIPTIONS[data.current.weather_code] ?? "unknown",
+  };
+}

--- a/backend/test/dashboardService.test.ts
+++ b/backend/test/dashboardService.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockEventFindMany = vi.hoisted(() => vi.fn());
 const mockTaskFindMany = vi.hoisted(() => vi.fn());
 const mockReminderFindMany = vi.hoisted(() => vi.fn());
+const mockGetWeather = vi.hoisted(() => vi.fn());
 
 vi.mock("../src/lib/prisma", () => ({
   prisma: {
@@ -12,6 +13,10 @@ vi.mock("../src/lib/prisma", () => ({
   },
 }));
 
+vi.mock("../src/services/weatherService", () => ({
+  getWeather: mockGetWeather,
+}));
+
 import { getDashboardSummary } from "../src/services/dashboardService";
 
 const userId = "user-1";
@@ -19,7 +24,7 @@ const userId = "user-1";
 describe("getDashboardSummary", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("returns events, tasks, and reminders for today", async () => {
+  it("returns events, tasks, reminders, and weather as null when no coords provided", async () => {
     const fakeEvents = [{ id: "evt-1", title: "Standup" }];
     const fakeTasks = [{ id: "task-1", title: "Fix bug" }];
     const fakeReminders = [{ id: "rem-1", title: "Call dentist" }];
@@ -34,7 +39,22 @@ describe("getDashboardSummary", () => {
       events: fakeEvents,
       tasks: fakeTasks,
       reminders: fakeReminders,
+      weather: null,
     });
+    expect(mockGetWeather).not.toHaveBeenCalled();
+  });
+
+  it("fetches weather when coords are provided", async () => {
+    const fakeWeather = { temperature: 72, condition: "clear sky" };
+    mockEventFindMany.mockResolvedValue([]);
+    mockTaskFindMany.mockResolvedValue([]);
+    mockReminderFindMany.mockResolvedValue([]);
+    mockGetWeather.mockResolvedValue(fakeWeather);
+
+    const result = await getDashboardSummary(userId, { lat: 34.05, lon: -118.25 });
+
+    expect(result.weather).toEqual(fakeWeather);
+    expect(mockGetWeather).toHaveBeenCalledWith(34.05, -118.25);
   });
 
   it("queries events within today's UTC boundaries ordered by startAt", async () => {
@@ -91,6 +111,6 @@ describe("getDashboardSummary", () => {
     mockReminderFindMany.mockResolvedValue([]);
 
     const result = await getDashboardSummary(userId);
-    expect(result).toEqual({ events: [], tasks: [], reminders: [] });
+    expect(result).toEqual({ events: [], tasks: [], reminders: [], weather: null });
   });
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       DATABASE_URL: postgresql://postgres:password@db:5432/orbit
       JWT_SECRET: ${JWT_SECRET}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+    volumes:
+      - ./backend/uploads:/app/uploads
     depends_on:
       - db
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,7 +1,9 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { Task, Reminder, Event } from "../types";
 import { apiFetch } from "../lib/api";
 import Layout from "../components/Layout";
+
+type Weather = { temperature: number; condition: string };
 
 type BriefingState = { status: "idle" } | { status: "loading" } | { status: "done"; text: string } | { status: "error"; message: string };
 
@@ -42,23 +44,45 @@ function Section({
   );
 }
 
+function getLocation(): Promise<{ lat: number; lon: number } | null> {
+  return new Promise((resolve) => {
+    if (!navigator.geolocation) {
+      resolve(null);
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => resolve({ lat: pos.coords.latitude, lon: pos.coords.longitude }),
+      () => resolve(null),
+      { timeout: 5000 }
+    );
+  });
+}
+
 export default function DashboardPage() {
   const [events, setEvents] = useState<Event[]>([]);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [reminders, setReminders] = useState<Reminder[]>([]);
+  const [weather, setWeather] = useState<Weather | null>(null);
   const [loading, setLoading] = useState(true);
   const [briefing, setBriefing] = useState<BriefingState>({ status: "idle" });
+  const coordsRef = useRef<{ lat: number; lon: number } | null>(null);
 
   useEffect(() => {
     async function load() {
-      const [evRes, taskRes, remRes] = await Promise.all([
-        apiFetch("/api/v1/events"),
+      const coords = await getLocation();
+      coordsRef.current = coords;
+
+      const params = coords ? `?lat=${coords.lat}&lon=${coords.lon}` : "";
+      const [dashRes, taskRes, remRes] = await Promise.all([
+        apiFetch(`/api/v1/dashboard${params}`),
         apiFetch("/api/v1/tasks"),
         apiFetch("/api/v1/reminders"),
       ]);
-      if (evRes.ok) {
-        const d = (await evRes.json()) as { data: Event[] };
-        setEvents(d.data);
+
+      if (dashRes.ok) {
+        const d = (await dashRes.json()) as { data: { events: Event[]; weather: Weather | null } };
+        setEvents(d.data.events);
+        setWeather(d.data.weather);
       }
       if (taskRes.ok) {
         const d = (await taskRes.json()) as { data: Task[] };
@@ -99,7 +123,16 @@ export default function DashboardPage() {
 
   async function handleGetBriefing() {
     setBriefing({ status: "loading" });
-    const res = await apiFetch("/api/v1/dashboard/briefing", { method: "POST" });
+    const payload: Record<string, unknown> = {
+      localTime: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: true }),
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    };
+    if (coordsRef.current) {
+      payload.lat = coordsRef.current.lat;
+      payload.lon = coordsRef.current.lon;
+    }
+    const body = JSON.stringify(payload);
+    const res = await apiFetch("/api/v1/dashboard/briefing", { method: "POST", body });
     if (!res.ok) {
       const data = (await res.json()) as { error?: string };
       setBriefing({ status: "error", message: data.error ?? "Failed to get briefing" });
@@ -123,6 +156,11 @@ export default function DashboardPage() {
           <div>
             <h1 className="text-3xl font-bold text-gray-900">Dashboard</h1>
             <p className="text-gray-500 mt-1">{todayLabel}</p>
+            {weather && (
+              <p className="text-gray-500 text-sm mt-1">
+                {weather.temperature}°F, {weather.condition}
+              </p>
+            )}
           </div>
           <button
             onClick={() => void handleGetBriefing()}


### PR DESCRIPTION
Add real-time weather data to the dashboard and AI briefing using Open-Meteo (free, no API key required) with browser geolocation.

Weather integration:
- weatherService calls Open-Meteo's current conditions endpoint with lat/lon from the frontend, returns temperature (°F) and condition using WMO weather code descriptions. No API key or env vars needed — replaces the original OpenWeatherMap + fixed WEATHER_LOCATION design to avoid key management and provide per-user location accuracy
- dashboardService accepts optional coords param and fetches weather in parallel with events/tasks/reminders
- GET /api/v1/dashboard accepts ?lat=&lon= query params
- Frontend DashboardPage uses navigator.geolocation to get the user's position (5s timeout, graceful null fallback if denied), sends coords to both the dashboard GET and briefing POST endpoints
- Weather displayed below the date on the Dashboard header

AI briefing time-of-day fixes:
- Frontend now sends localTime (e.g. "10:30 PM") and timezone (e.g. "America/Los_Angeles") in the briefing POST body
- Prompt includes the current time so Claude uses an appropriate greeting (morning/afternoon/evening) instead of always "good morning"
- Weather labeled as "current conditions as of right now" in the prompt so the model doesn't conflate it with a daytime forecast or speculate about later weather

Profile picture persistence fix (found during testing):
- Added volume mount ./backend/uploads:/app/uploads in docker-compose.yml so uploaded profile pictures survive container recreations
- Added fs.mkdirSync with recursive flag in profile route so the uploads directory is auto-created on first startup (fresh clone or new container)

Test updates:
- dashboardService tests updated to mock weatherService, verify getWeather is not called without coords and is called with correct lat/lon when coords are provided (6 tests total)