### PR TITLE
feat(frontend): establish design system for underwater theme (#113)

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,0 +1,28 @@
+import type { ButtonHTMLAttributes } from "react";
+
+type Variant = "primary" | "secondary";
+
+const styles: Record<Variant, string> = {
+  primary:
+    "bg-white/20 text-white border border-white/25 hover:bg-white/30 hover:-translate-y-0.5 hover:shadow-[0_4px_20px_rgba(255,255,255,0.15)] active:translate-y-0 active:shadow-[0_0_12px_rgba(255,255,255,0.2)]",
+  secondary:
+    "bg-white/10 text-white/70 border border-white/15 hover:bg-white/15 hover:text-white hover:-translate-y-0.5 hover:shadow-[0_4px_16px_rgba(255,255,255,0.08)] active:translate-y-0",
+};
+
+export default function Button({
+  variant = "primary",
+  className = "",
+  children,
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: Variant;
+}) {
+  return (
+    <button
+      className={`text-sm font-medium px-4 py-2 rounded-lg transition-all duration-150 disabled:opacity-50 disabled:pointer-events-none ${styles[variant]} ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+
+export default function Card({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`glass rounded-xl px-5 py-4 ${className}`}>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -15,32 +15,32 @@ export default function Layout({ children }: { children: ReactNode }) {
   const pictureUrl = profilePicture ? `${BASE_URL}${profilePicture}` : null;
 
   return (
-    <div className="min-h-screen bg-gray-100 flex flex-col p-8">
+    <div className="min-h-screen bg-ocean flex flex-col p-8">
       <div className="w-full flex justify-end items-center gap-3 mb-4">
         {pictureUrl ? (
           <a href="/profile">
             <img
               src={pictureUrl}
               alt="Profile"
-              className="w-8 h-8 rounded-full object-cover border border-gray-200"
+              className="w-8 h-8 rounded-full object-cover border border-white/30"
             />
           </a>
         ) : displayName ? (
           <a
             href="/profile"
-            className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center text-gray-500 text-sm font-bold"
+            className="w-8 h-8 rounded-full bg-white/15 flex items-center justify-center text-white/70 text-sm font-bold"
           >
             {displayName.charAt(0).toUpperCase()}
           </a>
         ) : null}
         {displayName && (
-          <a href="/profile" className="text-sm text-gray-500 hover:text-gray-700">
+          <a href="/profile" className="text-sm text-white/70 hover:text-white">
             {displayName}
           </a>
         )}
         <button
           onClick={handleSignOut}
-          className="text-sm font-medium text-gray-600 border border-gray-300 bg-white px-4 py-2 rounded hover:bg-gray-200 transition-colors duration-150"
+          className="text-sm font-medium text-white/70 border border-white/20 bg-white/10 px-4 py-2 rounded-lg hover:bg-white/20 hover:text-white transition-colors duration-150"
         >
           Sign out
         </button>

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import Button from "./Button";
+
+export default function Modal({
+  open,
+  onClose,
+  title,
+  children,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+}) {
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" />
+      <div
+        className="glass-strong relative rounded-2xl px-6 py-5 w-full max-w-md"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-white">{title}</h2>
+          <Button variant="secondary" onClick={onClose} className="px-2 py-1 text-xs">
+            ✕
+          </Button>
+        </div>
+        <div className="text-white/80 text-sm">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,7 +3,34 @@
 @layer base {
   button {
     cursor: pointer;
-    transition: background-color 150ms ease, color 150ms ease, border-color 150ms ease, opacity 150ms ease;
+    transition: background-color 150ms ease, color 150ms ease, border-color 150ms ease, opacity 150ms ease, transform 150ms ease, box-shadow 150ms ease;
   }
 }
 
+@layer utilities {
+  .bg-ocean {
+    background:
+      radial-gradient(ellipse at 0% 0%, rgba(26, 138, 122, 0.45) 0%, transparent 50%),
+      radial-gradient(ellipse at 100% 100%, rgba(45, 168, 142, 0.4) 0%, transparent 50%),
+      radial-gradient(ellipse at 100% 0%, rgba(13, 95, 106, 0.35) 0%, transparent 45%),
+      radial-gradient(ellipse at 0% 100%, rgba(14, 61, 94, 0.35) 0%, transparent 45%),
+      radial-gradient(ellipse at 50% 50%, #0a1e38 0%, #0f2b4c 100%);
+    background-attachment: fixed;
+  }
+
+  .glass {
+    background: rgba(255, 255, 255, 0.12);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+  }
+
+  .glass-strong {
+    background: rgba(255, 255, 255, 0.18);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+  }
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef } from "react";
 import type { Task, Reminder, Event } from "../types";
 import { apiFetch } from "../lib/api";
 import Layout from "../components/Layout";
+import Card from "../components/Card";
+import Button from "../components/Button";
 
 type Weather = { temperature: number; condition: string };
 
@@ -32,11 +34,11 @@ function Section({
 }) {
   return (
     <div>
-      <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
+      <h2 className="text-xs font-semibold text-white/50 uppercase tracking-wide mb-3">
         {title}
       </h2>
       {count === 0 ? (
-        <p className="text-xs text-gray-300 italic">{empty}</p>
+        <p className="text-xs text-white/30 italic">{empty}</p>
       ) : (
         <div className="flex flex-col gap-2">{children}</div>
       )}
@@ -154,53 +156,49 @@ export default function DashboardPage() {
       <div className="max-w-2xl mx-auto">
         <div className="mb-8 flex items-start justify-between gap-4">
           <div>
-            <h1 className="text-3xl font-bold text-gray-900">Dashboard</h1>
-            <p className="text-gray-500 mt-1">{todayLabel}</p>
+            <h1 className="text-3xl font-bold text-white">Dashboard</h1>
+            <p className="text-white/50 mt-1">{todayLabel}</p>
             {weather && (
-              <p className="text-gray-500 text-sm mt-1">
+              <p className="text-white/50 text-sm mt-1">
                 {weather.temperature}°F, {weather.condition}
               </p>
             )}
           </div>
-          <button
+          <Button
             onClick={() => void handleGetBriefing()}
             disabled={briefing.status === "loading"}
-            className="shrink-0 text-sm font-medium bg-slate-600 text-white px-4 py-2 rounded hover:bg-slate-500 disabled:opacity-50 transition-colors duration-150"
           >
             {briefing.status === "loading" ? "Getting briefing…" : "Get AI Briefing"}
-          </button>
+          </Button>
         </div>
 
         {briefing.status === "done" && (
-          <div className="mb-8 bg-slate-50 border border-slate-200 rounded-lg px-5 py-4">
-            <p className="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-2">AI Briefing</p>
-            <p className="text-sm text-slate-700 leading-relaxed">{briefing.text}</p>
-          </div>
+          <Card className="mb-8">
+            <p className="text-xs font-semibold text-white/40 uppercase tracking-wide mb-2">AI Briefing</p>
+            <p className="text-sm text-white/80 leading-relaxed">{briefing.text}</p>
+          </Card>
         )}
         {briefing.status === "error" && (
-          <div className="mb-8 bg-red-50 border border-red-200 rounded-lg px-5 py-4">
-            <p className="text-sm text-red-600">{briefing.message}</p>
-          </div>
+          <Card className="mb-8 border-red-400/30">
+            <p className="text-sm text-red-300">{briefing.message}</p>
+          </Card>
         )}
 
         {loading ? (
-          <p className="text-sm text-gray-400">Loading…</p>
+          <p className="text-sm text-white/40">Loading…</p>
         ) : (
           <div className="flex flex-col gap-8">
             <Section title="Today's Events" empty="No events today." count={todayEvents.length}>
               {todayEvents.map((e) => (
-                <div
-                  key={e.id}
-                  className="bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3"
-                >
-                  <p className="text-gray-900 font-medium text-sm">{e.title}</p>
-                  <p className="text-xs text-gray-400 mt-0.5">
+                <Card key={e.id}>
+                  <p className="text-white font-medium text-sm">{e.title}</p>
+                  <p className="text-xs text-white/40 mt-0.5">
                     {formatTime(e.startAt)} – {formatTime(e.endAt)}
                   </p>
                   {e.description && (
-                    <p className="text-xs text-gray-500 mt-0.5">{e.description}</p>
+                    <p className="text-xs text-white/50 mt-0.5">{e.description}</p>
                   )}
-                </div>
+                </Card>
               ))}
             </Section>
 
@@ -212,34 +210,28 @@ export default function DashboardPage() {
               {dueTasks.map((t) => {
                 const isOverdue = t.dueDate && new Date(t.dueDate) < todayMidnight;
                 return (
-                  <div
-                    key={t.id}
-                    className="bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3"
-                  >
-                    <p className="text-gray-900 font-medium text-sm">{t.title}</p>
+                  <Card key={t.id}>
+                    <p className="text-white font-medium text-sm">{t.title}</p>
                     {t.dueDate && (
-                      <p className={`text-xs mt-0.5 ${isOverdue ? "text-red-400" : "text-gray-400"}`}>
+                      <p className={`text-xs mt-0.5 ${isOverdue ? "text-red-300" : "text-white/40"}`}>
                         {isOverdue ? "Overdue · " : "Due "}
                         {new Date(t.dueDate).toLocaleDateString()}
                       </p>
                     )}
                     {t.description && (
-                      <p className="text-xs text-gray-500 mt-0.5">{t.description}</p>
+                      <p className="text-xs text-white/50 mt-0.5">{t.description}</p>
                     )}
-                  </div>
+                  </Card>
                 );
               })}
             </Section>
 
             <Section title="Reminders Today" empty="No reminders today." count={todayReminders.length}>
               {todayReminders.map((r) => (
-                <div
-                  key={r.id}
-                  className="bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3"
-                >
-                  <p className="text-gray-900 font-medium text-sm">{r.title}</p>
-                  <p className="text-xs text-gray-400 mt-0.5">{formatTime(r.scheduledAt)}</p>
-                </div>
+                <Card key={r.id}>
+                  <p className="text-white font-medium text-sm">{r.title}</p>
+                  <p className="text-xs text-white/40 mt-0.5">{formatTime(r.scheduledAt)}</p>
+                </Card>
               ))}
             </Section>
           </div>


### PR DESCRIPTION
Add the visual foundation for the M7 UI redesign with an ocean-themed design system and reusable styled components.

Background:
- bg-ocean utility uses layered radial gradients — deep navy center (#0a1e38) with teal/seafoam pooling in the corners via four radial overlays, fixed attachment so it stays anchored during scroll
- Layout updated from bg-gray-100 to bg-ocean with all header elements (avatar, name, sign-out) switched to white/translucent styling

Components:
- Card: frosted glass panel (12% white bg, 16px backdrop blur, soft white border and floating shadow), rounded-xl, accepts className
- Button: primary (brighter glass + white text) and secondary (subtle glass + muted text) variants. Hover lifts with glow shadow, active press snaps back with inner glow. Disabled state handled
- Modal: fixed overlay with black/40 backdrop blur, glass-strong content panel (18% white, 20px blur), title bar with close button, click-outside-to-dismiss

CSS utilities:
- glass and glass-strong classes in index.css for consistent frosted glass treatment across components
- Base button transitions extended with transform and box-shadow

Proof of concept:
- DashboardPage fully converted to new theme — all cards, buttons, and text colors use the new components and white/opacity scale for legibility against the gradient background