### PR TITLE
feat(frontend): redesign login and dashboard as the app hub (#114)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,6 @@ import RemindersPage from "./pages/RemindersPage";
 import CalendarPage from "./pages/CalendarPage";
 import DashboardPage from "./pages/DashboardPage";
 import ProfilePage from "./pages/ProfilePage";
-import Layout from "./components/Layout";
 
 export default function App() {
   const path = window.location.pathname;
@@ -25,50 +24,7 @@ export default function App() {
   if (path === "/tasks") return <TasksPage />;
   if (path === "/reminders") return <RemindersPage />;
   if (path === "/calendar") return <CalendarPage />;
-  if (path === "/dashboard") return <DashboardPage />;
   if (path === "/profile") return <ProfilePage />;
 
-  return (
-    <Layout>
-      <div className="flex flex-col items-center mt-8">
-        <div className="border border-gray-300 bg-white rounded-xl px-10 py-5 shadow-sm mb-12">
-          <h1 className="text-4xl font-bold text-gray-800 tracking-tight">
-            Code Impact Training
-          </h1>
-        </div>
-        <div className="flex flex-col items-center gap-3">
-          <a
-            href="/tasks"
-            className="w-52 text-center bg-slate-600 text-white text-sm font-medium px-6 py-3 rounded hover:bg-slate-500 transition-colors duration-150"
-          >
-            Go to Tasks
-          </a>
-          <a
-            href="/reminders"
-            className="w-52 text-center bg-slate-600 text-white text-sm font-medium px-6 py-3 rounded hover:bg-slate-500 transition-colors duration-150"
-          >
-            Go to Reminders
-          </a>
-          <a
-            href="/calendar"
-            className="w-52 text-center bg-slate-600 text-white text-sm font-medium px-6 py-3 rounded hover:bg-slate-500 transition-colors duration-150"
-          >
-            Go to Calendar
-          </a>
-          <a
-            href="/dashboard"
-            className="w-52 text-center bg-slate-600 text-white text-sm font-medium px-6 py-3 rounded hover:bg-slate-500 transition-colors duration-150"
-          >
-            Go to Dashboard
-          </a>
-          <a
-            href="/profile"
-            className="w-52 text-center bg-slate-600 text-white text-sm font-medium px-6 py-3 rounded hover:bg-slate-500 transition-colors duration-150"
-          >
-            Go to Profile
-          </a>
-        </div>
-      </div>
-    </Layout>
-  );
+  return <DashboardPage />;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,6 +26,15 @@
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
   }
 
+  @keyframes fade-in {
+    from { opacity: 0; transform: translateY(12px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  .animate-fade-in {
+    animation: fade-in 0.8s ease-out both;
+  }
+
   .glass-strong {
     background: rgba(255, 255, 255, 0.18);
     backdrop-filter: blur(20px);

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -6,58 +6,141 @@ import Card from "../components/Card";
 import Button from "../components/Button";
 
 type Weather = { temperature: number; condition: string };
-
-type BriefingState = { status: "idle" } | { status: "loading" } | { status: "done"; text: string } | { status: "error"; message: string };
-
-function todayBounds() {
-  const start = new Date();
-  start.setHours(0, 0, 0, 0);
-  const end = new Date();
-  end.setHours(23, 59, 59, 999);
-  return { start, end };
-}
+type BriefingState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "done"; text: string }
+  | { status: "error"; message: string };
 
 function formatTime(iso: string) {
   return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-function Section({
-  title,
-  empty,
-  count,
-  children,
-}: {
-  title: string;
-  empty: string;
-  count: number;
-  children: React.ReactNode;
-}) {
-  return (
-    <div>
-      <h2 className="text-xs font-semibold text-white/50 uppercase tracking-wide mb-3">
-        {title}
-      </h2>
-      {count === 0 ? (
-        <p className="text-xs text-white/30 italic">{empty}</p>
-      ) : (
-        <div className="flex flex-col gap-2">{children}</div>
-      )}
-    </div>
-  );
-}
-
 function getLocation(): Promise<{ lat: number; lon: number } | null> {
   return new Promise((resolve) => {
-    if (!navigator.geolocation) {
-      resolve(null);
-      return;
-    }
+    if (!navigator.geolocation) { resolve(null); return; }
     navigator.geolocation.getCurrentPosition(
       (pos) => resolve({ lat: pos.coords.latitude, lon: pos.coords.longitude }),
       () => resolve(null),
-      { timeout: 5000 }
+      { timeout: 5000 },
     );
   });
+}
+
+function ExpandableTask({
+  task,
+  onComplete,
+  onUpdate,
+}: {
+  task: Task;
+  onComplete: (id: string) => void;
+  onUpdate: (id: string, fields: { title?: string; description?: string | null }) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState(task.title);
+  const [description, setDescription] = useState(task.description ?? "");
+
+  function handleSave() {
+    onUpdate(task.id, { title, description: description || null });
+    setOpen(false);
+  }
+
+  return (
+    <Card>
+      <div className="flex items-start gap-3">
+        <button
+          onClick={(e) => { e.stopPropagation(); onComplete(task.id); }}
+          className="mt-0.5 w-4 h-4 rounded border border-white/30 shrink-0 hover:bg-white/20 transition-colors"
+          aria-label="Complete task"
+        />
+        <div className="flex-1 cursor-pointer" onClick={() => setOpen(!open)}>
+          <p className="text-white font-medium text-sm">{task.title}</p>
+          {task.dueDate && (
+            <p className="text-xs text-white/40 mt-0.5">
+              Due {new Date(task.dueDate).toLocaleDateString()}
+            </p>
+          )}
+        </div>
+      </div>
+      {open && (
+        <div className="mt-3 pt-3 border-t border-white/10">
+          <label className="block mb-2">
+            <span className="text-xs text-white/50">Title</span>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-1.5 text-sm text-white focus:outline-none focus:border-white/40"
+            />
+          </label>
+          <label className="block mb-3">
+            <span className="text-xs text-white/50">Description</span>
+            <input
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-1.5 text-sm text-white focus:outline-none focus:border-white/40"
+            />
+          </label>
+          <div className="flex gap-2">
+            <Button onClick={handleSave} className="text-xs px-3 py-1">Save</Button>
+            <Button variant="secondary" onClick={() => setOpen(false)} className="text-xs px-3 py-1">Cancel</Button>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function ExpandableReminder({
+  reminder,
+  onComplete,
+  onUpdate,
+}: {
+  reminder: Reminder;
+  onComplete: (id: string) => void;
+  onUpdate: (id: string, fields: { title?: string }) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState(reminder.title);
+
+  function handleSave() {
+    onUpdate(reminder.id, { title });
+    setOpen(false);
+  }
+
+  return (
+    <Card>
+      <div className="flex items-start gap-3">
+        <button
+          onClick={(e) => { e.stopPropagation(); onComplete(reminder.id); }}
+          className="mt-0.5 w-4 h-4 rounded border border-white/30 shrink-0 hover:bg-white/20 transition-colors"
+          aria-label="Complete reminder"
+        />
+        <div className="flex-1 cursor-pointer" onClick={() => setOpen(!open)}>
+          <p className="text-white font-medium text-sm">{reminder.title}</p>
+          <p className="text-xs text-white/40 mt-0.5">{formatTime(reminder.scheduledAt)}</p>
+        </div>
+      </div>
+      {open && (
+        <div className="mt-3 pt-3 border-t border-white/10">
+          <label className="block mb-3">
+            <span className="text-xs text-white/50">Title</span>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-1.5 text-sm text-white focus:outline-none focus:border-white/40"
+            />
+          </label>
+          <div className="flex gap-2">
+            <Button onClick={handleSave} className="text-xs px-3 py-1">Save</Button>
+            <Button variant="secondary" onClick={() => setOpen(false)} className="text-xs px-3 py-1">Cancel</Button>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
 }
 
 export default function DashboardPage() {
@@ -67,20 +150,31 @@ export default function DashboardPage() {
   const [weather, setWeather] = useState<Weather | null>(null);
   const [loading, setLoading] = useState(true);
   const [briefing, setBriefing] = useState<BriefingState>({ status: "idle" });
+  const [showWelcome, setShowWelcome] = useState(() => {
+    if (localStorage.getItem("showWelcome") === "true") {
+      localStorage.removeItem("showWelcome");
+      return true;
+    }
+    return false;
+  });
   const coordsRef = useRef<{ lat: number; lon: number } | null>(null);
+
+  useEffect(() => {
+    if (!showWelcome) return;
+    const timer = setTimeout(() => setShowWelcome(false), 3000);
+    return () => clearTimeout(timer);
+  }, [showWelcome]);
 
   useEffect(() => {
     async function load() {
       const coords = await getLocation();
       coordsRef.current = coords;
-
       const params = coords ? `?lat=${coords.lat}&lon=${coords.lon}` : "";
       const [dashRes, taskRes, remRes] = await Promise.all([
         apiFetch(`/api/v1/dashboard${params}`),
         apiFetch("/api/v1/tasks"),
         apiFetch("/api/v1/reminders"),
       ]);
-
       if (dashRes.ok) {
         const d = (await dashRes.json()) as { data: { events: Event[]; weather: Weather | null } };
         setEvents(d.data.events);
@@ -99,21 +193,17 @@ export default function DashboardPage() {
     void load();
   }, []);
 
-  const { start: todayStart, end: todayEnd } = todayBounds();
-  const todayMidnight = new Date();
-  todayMidnight.setHours(0, 0, 0, 0);
+  const now = new Date();
+  const todayStart = new Date(now); todayStart.setHours(0, 0, 0, 0);
+  const todayEnd = new Date(now); todayEnd.setHours(23, 59, 59, 999);
 
   const todayEvents = events
-    .filter((e) => {
-      const s = new Date(e.startAt);
-      return s >= todayStart && s <= todayEnd;
-    })
+    .filter((e) => { const s = new Date(e.startAt); return s >= todayStart && s <= todayEnd; })
     .sort((a, b) => new Date(a.startAt).getTime() - new Date(b.startAt).getTime());
 
   const dueTasks = tasks.filter((t) => {
     if (t.status !== "UPCOMING" || !t.dueDate) return false;
-    const d = new Date(t.dueDate);
-    d.setHours(23, 59, 59, 999);
+    const d = new Date(t.dueDate); d.setHours(23, 59, 59, 999);
     return d <= todayEnd;
   });
 
@@ -123,18 +213,46 @@ export default function DashboardPage() {
     return d >= todayStart && d <= todayEnd;
   });
 
+  const totalItems = dueTasks.length + todayReminders.length;
+  const completedToday = tasks.filter((t) => t.status === "COMPLETED").length
+    + reminders.filter((r) => r.status === "COMPLETED" && new Date(r.scheduledAt) >= todayStart && new Date(r.scheduledAt) <= todayEnd).length;
+  const allToday = totalItems + completedToday;
+  const pct = allToday === 0 ? 0 : Math.round((completedToday / allToday) * 100);
+
+  async function handleCompleteTask(id: string) {
+    const res = await apiFetch(`/api/v1/tasks/${id}/complete`, { method: "PATCH" });
+    if (res.ok) setTasks((prev) => prev.map((t) => t.id === id ? { ...t, status: "COMPLETED" as const } : t));
+  }
+
+  async function handleUpdateTask(id: string, fields: { title?: string; description?: string | null }) {
+    const res = await apiFetch(`/api/v1/tasks/${id}`, { method: "PATCH", body: JSON.stringify(fields) });
+    if (res.ok) {
+      const d = (await res.json()) as { data: Task };
+      setTasks((prev) => prev.map((t) => t.id === id ? d.data : t));
+    }
+  }
+
+  async function handleCompleteReminder(id: string) {
+    const res = await apiFetch(`/api/v1/reminders/${id}/complete`, { method: "PATCH" });
+    if (res.ok) setReminders((prev) => prev.map((r) => r.id === id ? { ...r, status: "COMPLETED" as const } : r));
+  }
+
+  async function handleUpdateReminder(id: string, fields: { title?: string }) {
+    const res = await apiFetch(`/api/v1/reminders/${id}`, { method: "PATCH", body: JSON.stringify(fields) });
+    if (res.ok) {
+      const d = (await res.json()) as { data: Reminder };
+      setReminders((prev) => prev.map((r) => r.id === id ? d.data : r));
+    }
+  }
+
   async function handleGetBriefing() {
     setBriefing({ status: "loading" });
     const payload: Record<string, unknown> = {
       localTime: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: true }),
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     };
-    if (coordsRef.current) {
-      payload.lat = coordsRef.current.lat;
-      payload.lon = coordsRef.current.lon;
-    }
-    const body = JSON.stringify(payload);
-    const res = await apiFetch("/api/v1/dashboard/briefing", { method: "POST", body });
+    if (coordsRef.current) { payload.lat = coordsRef.current.lat; payload.lon = coordsRef.current.lon; }
+    const res = await apiFetch("/api/v1/dashboard/briefing", { method: "POST", body: JSON.stringify(payload) });
     if (!res.ok) {
       const data = (await res.json()) as { error?: string };
       setBriefing({ status: "error", message: data.error ?? "Failed to get briefing" });
@@ -144,96 +262,143 @@ export default function DashboardPage() {
     setBriefing({ status: "done", text: data.data.briefing });
   }
 
-  const todayLabel = new Date().toLocaleDateString([], {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
+  const displayName = localStorage.getItem("displayName") ?? "there";
+  const todayLabel = now.toLocaleDateString([], { weekday: "long", month: "long", day: "numeric" });
+
+  if (showWelcome) {
+    return (
+      <div className="min-h-screen bg-ocean flex items-center justify-center">
+        <div className="text-center animate-fade-in">
+          <h1 className="text-4xl font-bold text-white mb-2">Welcome to Orbit</h1>
+          <p className="text-lg text-white/60">Let&apos;s get you set up, {displayName}.</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <Layout>
-      <div className="max-w-2xl mx-auto">
-        <div className="mb-8 flex items-start justify-between gap-4">
-          <div>
-            <h1 className="text-3xl font-bold text-white">Dashboard</h1>
-            <p className="text-white/50 mt-1">{todayLabel}</p>
-            {weather && (
-              <p className="text-white/50 text-sm mt-1">
-                {weather.temperature}°F, {weather.condition}
-              </p>
-            )}
-          </div>
-          <Button
-            onClick={() => void handleGetBriefing()}
-            disabled={briefing.status === "loading"}
-          >
-            {briefing.status === "loading" ? "Getting briefing…" : "Get AI Briefing"}
-          </Button>
+      <div className="max-w-4xl mx-auto">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-white">Hey, {displayName}</h1>
+          <p className="text-white/50 mt-1">{todayLabel}</p>
         </div>
 
-        {briefing.status === "done" && (
-          <Card className="mb-8">
-            <p className="text-xs font-semibold text-white/40 uppercase tracking-wide mb-2">AI Briefing</p>
-            <p className="text-sm text-white/80 leading-relaxed">{briefing.text}</p>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+          {/* Weather tile */}
+          <Card className="flex flex-col items-center justify-center py-6">
+            {weather ? (
+              <>
+                <p className="text-3xl font-bold text-white">{weather.temperature}°F</p>
+                <p className="text-sm text-white/50 mt-1 capitalize">{weather.condition}</p>
+              </>
+            ) : (
+              <p className="text-sm text-white/30">No weather data</p>
+            )}
           </Card>
-        )}
-        {briefing.status === "error" && (
-          <Card className="mb-8 border-red-400/30">
-            <p className="text-sm text-red-300">{briefing.message}</p>
+
+          {/* Completion tile */}
+          <Card className="flex flex-col items-center justify-center py-6">
+            <p className="text-3xl font-bold text-white">{pct}%</p>
+            <p className="text-sm text-white/50 mt-1">Completed today</p>
+            <div className="w-full mt-3 bg-white/10 rounded-full h-1.5">
+              <div
+                className="bg-emerald-400 h-1.5 rounded-full transition-all duration-500"
+                style={{ width: `${pct}%` }}
+              />
+            </div>
           </Card>
-        )}
+
+          {/* Briefing tile */}
+          <Card className="flex flex-col items-center justify-center py-6">
+            {briefing.status === "done" ? (
+              <p className="text-sm text-white/80 leading-relaxed text-center">{briefing.text}</p>
+            ) : briefing.status === "error" ? (
+              <p className="text-sm text-red-300 text-center">{briefing.message}</p>
+            ) : (
+              <Button
+                onClick={() => void handleGetBriefing()}
+                disabled={briefing.status === "loading"}
+              >
+                {briefing.status === "loading" ? "Loading…" : "Get AI Briefing"}
+              </Button>
+            )}
+          </Card>
+        </div>
 
         {loading ? (
           <p className="text-sm text-white/40">Loading…</p>
         ) : (
-          <div className="flex flex-col gap-8">
-            <Section title="Today's Events" empty="No events today." count={todayEvents.length}>
-              {todayEvents.map((e) => (
-                <Card key={e.id}>
-                  <p className="text-white font-medium text-sm">{e.title}</p>
-                  <p className="text-xs text-white/40 mt-0.5">
-                    {formatTime(e.startAt)} – {formatTime(e.endAt)}
-                  </p>
-                  {e.description && (
-                    <p className="text-xs text-white/50 mt-0.5">{e.description}</p>
-                  )}
-                </Card>
-              ))}
-            </Section>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {/* Tasks tile */}
+            <div>
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="text-xs font-semibold text-white/50 uppercase tracking-wide">Tasks</h2>
+                <a href="/tasks" className="text-xs text-white/30 hover:text-white/60">View all</a>
+              </div>
+              {dueTasks.length === 0 ? (
+                <p className="text-xs text-white/30 italic">No tasks due today</p>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  {dueTasks.map((t) => (
+                    <ExpandableTask key={t.id} task={t} onComplete={handleCompleteTask} onUpdate={handleUpdateTask} />
+                  ))}
+                </div>
+              )}
+            </div>
 
-            <Section
-              title="Tasks Due Today"
-              empty="No overdue or due-today tasks."
-              count={dueTasks.length}
-            >
-              {dueTasks.map((t) => {
-                const isOverdue = t.dueDate && new Date(t.dueDate) < todayMidnight;
-                return (
-                  <Card key={t.id}>
-                    <p className="text-white font-medium text-sm">{t.title}</p>
-                    {t.dueDate && (
-                      <p className={`text-xs mt-0.5 ${isOverdue ? "text-red-300" : "text-white/40"}`}>
-                        {isOverdue ? "Overdue · " : "Due "}
-                        {new Date(t.dueDate).toLocaleDateString()}
+            {/* Reminders tile */}
+            <div>
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="text-xs font-semibold text-white/50 uppercase tracking-wide">Reminders</h2>
+                <a href="/reminders" className="text-xs text-white/30 hover:text-white/60">View all</a>
+              </div>
+              {todayReminders.length === 0 ? (
+                <p className="text-xs text-white/30 italic">No reminders today</p>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  {todayReminders.map((r) => (
+                    <ExpandableReminder key={r.id} reminder={r} onComplete={handleCompleteReminder} onUpdate={handleUpdateReminder} />
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Events tile */}
+            <div>
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="text-xs font-semibold text-white/50 uppercase tracking-wide">Today&apos;s Events</h2>
+                <a href="/calendar" className="text-xs text-white/30 hover:text-white/60">View all</a>
+              </div>
+              {todayEvents.length === 0 ? (
+                <p className="text-xs text-white/30 italic">No events today</p>
+              ) : (
+                <div className="flex flex-col gap-2">
+                  {todayEvents.map((e) => (
+                    <Card key={e.id}>
+                      <p className="text-white font-medium text-sm">{e.title}</p>
+                      <p className="text-xs text-white/40 mt-0.5">
+                        {formatTime(e.startAt)} – {formatTime(e.endAt)}
                       </p>
-                    )}
-                    {t.description && (
-                      <p className="text-xs text-white/50 mt-0.5">{t.description}</p>
-                    )}
-                  </Card>
-                );
-              })}
-            </Section>
+                      {e.description && <p className="text-xs text-white/50 mt-0.5">{e.description}</p>}
+                    </Card>
+                  ))}
+                </div>
+              )}
+            </div>
 
-            <Section title="Reminders Today" empty="No reminders today." count={todayReminders.length}>
-              {todayReminders.map((r) => (
-                <Card key={r.id}>
-                  <p className="text-white font-medium text-sm">{r.title}</p>
-                  <p className="text-xs text-white/40 mt-0.5">{formatTime(r.scheduledAt)}</p>
-                </Card>
-              ))}
-            </Section>
+            {/* Profile tile */}
+            <a href="/profile" className="block">
+              <Card className="flex items-center gap-4 hover:bg-white/15 transition-colors cursor-pointer">
+                <div className="w-10 h-10 rounded-full bg-white/15 flex items-center justify-center text-white font-bold">
+                  {displayName.charAt(0).toUpperCase()}
+                </div>
+                <div>
+                  <p className="text-white font-medium text-sm">{displayName}</p>
+                  <p className="text-xs text-white/40">View profile</p>
+                </div>
+              </Card>
+            </a>
           </div>
         )}
       </div>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { apiFetch } from "../lib/api";
+import Button from "../components/Button";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -24,42 +25,40 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-8">
+    <div className="min-h-screen bg-ocean flex items-center justify-center p-8">
       <form
         onSubmit={handleSubmit}
-        className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 w-full max-w-md"
+        className="glass-strong rounded-2xl p-8 w-full max-w-md"
       >
-        <h1 className="text-2xl font-bold text-gray-900 mb-6">Log in</h1>
-        {error && <p className="text-red-600 text-sm mb-4">{error}</p>}
+        <h1 className="text-3xl font-bold text-white mb-1">Welcome to Orbit</h1>
+        <p className="text-sm text-white/50 mb-8">Sign in to your account</p>
+        {error && <p className="text-red-300 text-sm mb-4">{error}</p>}
         <label className="block mb-4">
-          <span className="text-sm font-medium text-gray-700">Email</span>
+          <span className="text-sm font-medium text-white/70">Email</span>
           <input
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
-            className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+            className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/20"
           />
         </label>
         <label className="block mb-6">
-          <span className="text-sm font-medium text-gray-700">Password</span>
+          <span className="text-sm font-medium text-white/70">Password</span>
           <input
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
-            className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+            className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/20"
           />
         </label>
-        <button
-          type="submit"
-          className="w-full bg-gray-900 text-white rounded px-4 py-2 text-sm font-medium hover:bg-gray-700 transition-colors duration-150"
-        >
+        <Button type="submit" className="w-full py-3">
           Log in
-        </button>
-        <p className="text-sm text-gray-500 mt-4 text-center">
+        </Button>
+        <p className="text-sm text-white/40 mt-4 text-center">
           Don&apos;t have an account?{" "}
-          <a href="/signup" className="text-gray-900 font-medium hover:underline">
+          <a href="/signup" className="text-white/70 font-medium hover:text-white">
             Sign up
           </a>
         </p>

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { apiFetch } from "../lib/api";
+import Button from "../components/Button";
 
 export default function SignupPage() {
   const [email, setEmail] = useState("");
@@ -21,56 +22,55 @@ export default function SignupPage() {
     }
     localStorage.setItem("token", data.data!.token);
     localStorage.setItem("displayName", displayName);
+    localStorage.setItem("showWelcome", "true");
     window.location.href = "/";
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-8">
+    <div className="min-h-screen bg-ocean flex items-center justify-center p-8">
       <form
         onSubmit={handleSubmit}
-        className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 w-full max-w-md"
+        className="glass-strong rounded-2xl p-8 w-full max-w-md"
       >
-        <h1 className="text-2xl font-bold text-gray-900 mb-6">Sign up</h1>
-        {error && <p className="text-red-600 text-sm mb-4">{error}</p>}
+        <h1 className="text-3xl font-bold text-white mb-1">Join Orbit</h1>
+        <p className="text-sm text-white/50 mb-8">Create your account to get started</p>
+        {error && <p className="text-red-300 text-sm mb-4">{error}</p>}
         <label className="block mb-4">
-          <span className="text-sm font-medium text-gray-700">Display name</span>
+          <span className="text-sm font-medium text-white/70">Display name</span>
           <input
             type="text"
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
             required
-            className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+            className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/20"
           />
         </label>
         <label className="block mb-4">
-          <span className="text-sm font-medium text-gray-700">Email</span>
+          <span className="text-sm font-medium text-white/70">Email</span>
           <input
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
-            className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+            className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/20"
           />
         </label>
         <label className="block mb-6">
-          <span className="text-sm font-medium text-gray-700">Password</span>
+          <span className="text-sm font-medium text-white/70">Password</span>
           <input
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
-            className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+            className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white placeholder-white/30 focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/20"
           />
         </label>
-        <button
-          type="submit"
-          className="w-full bg-gray-900 text-white rounded px-4 py-2 text-sm font-medium hover:bg-gray-700 transition-colors duration-150"
-        >
+        <Button type="submit" className="w-full py-3">
           Create account
-        </button>
-        <p className="text-sm text-gray-500 mt-4 text-center">
+        </Button>
+        <p className="text-sm text-white/40 mt-4 text-center">
           Already have an account?{" "}
-          <a href="/login" className="text-gray-900 font-medium hover:underline">
+          <a href="/login" className="text-white/70 font-medium hover:text-white">
             Log in
           </a>
         </p>


### PR DESCRIPTION
Redesign login/signup pages with Orbit branding and rebuild the Dashboard as a tile-based hub replacing the old button-list home page.

Login & Signup:
- Ocean gradient background with frosted glass forms
- "Welcome to Orbit" / "Join Orbit" headings, translucent inputs
- Uses new Button component from the design system
- Signup sets a showWelcome flag triggering a one-time animated welcome screen (fade-in, 3s) before landing on the dashboard

Dashboard hub (now the home page at /):
- Top row: 3-column grid with Weather tile (temperature + condition), Completion percentage tile (animated emerald progress bar tracking tasks and reminders completed today), and AI Briefing tile
- Bottom: 2-column grid with Tasks, Reminders, Events, and Profile
- ExpandableTask and ExpandableReminder components — click to expand inline edit fields (title, description), save/cancel buttons
- Quick-complete checkbox on each task/reminder card calls PATCH /:id/complete without opening the card
- Completing items immediately recalculates the completion percentage
- "View all" links on each section navigate to dedicated pages
- Profile tile shows avatar initial and display name

Routing:
- Dashboard is now the default route (/) — old hub page with vertical button list removed
- /dashboard route removed (consolidated into /)

CSS:
- Added animate-fade-in keyframe for welcome screen transition