### PR TITLE
feat(frontend): add sidebar navigation and streak system (#115)

### DIFF
--- a/backend/prisma/migrations/20260618022855_add_streak_system/migration.sql
+++ b/backend/prisma/migrations/20260618022855_add_streak_system/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "currentStreak" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "dailyGoal" INTEGER NOT NULL DEFAULT 50,
+ADD COLUMN     "lastStreakDate" TIMESTAMP(3),
+ADD COLUMN     "longestStreak" INTEGER NOT NULL DEFAULT 0;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,16 +19,20 @@ enum RepeatFrequency {
 }
 
 model User {
-  id             String   @id @default(cuid())
-  email          String   @unique
-  passwordHash   String
-  displayName    String
-  profilePicture String?
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
-  tasks          Task[]
-  reminders      Reminder[]
-  events         Event[]
+  id               String    @id @default(cuid())
+  email            String    @unique
+  passwordHash     String
+  displayName      String
+  profilePicture   String?
+  dailyGoal        Int       @default(50)
+  currentStreak    Int       @default(0)
+  longestStreak    Int       @default(0)
+  lastStreakDate   DateTime?
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+  tasks            Task[]
+  reminders        Reminder[]
+  events           Event[]
 }
 
 model Task {

--- a/backend/src/controllers/dashboardController.ts
+++ b/backend/src/controllers/dashboardController.ts
@@ -1,5 +1,7 @@
 import { Request, Response } from "express";
 import { getDashboardSummary } from "../services/dashboardService";
+import { evaluateStreak, getEarnedBadges, getNextBadge } from "../services/streakService";
+import { getProfile } from "../services/profileService";
 
 export async function getDashboardController(req: Request, res: Response) {
   const lat = parseFloat(req.query.lat as string);
@@ -7,5 +9,29 @@ export async function getDashboardController(req: Request, res: Response) {
   const coords = !isNaN(lat) && !isNaN(lon) ? { lat, lon } : undefined;
 
   const data = await getDashboardSummary(req.userId!, coords);
-  res.json({ success: true, data });
+
+  const totalItems = data.tasks.length + data.reminders.length;
+  const completed = data.tasks.filter((t) => t.status === "COMPLETED").length
+    + data.reminders.filter((r) => r.status === "COMPLETED").length;
+  const pct = totalItems + completed === 0 ? 0 : Math.round((completed / (totalItems + completed)) * 100);
+
+  await evaluateStreak(req.userId!, pct);
+
+  const profile = await getProfile(req.userId!);
+  const badges = getEarnedBadges(profile.longestStreak);
+  const nextBadge = getNextBadge(profile.longestStreak);
+
+  res.json({
+    success: true,
+    data: {
+      ...data,
+      streak: {
+        current: profile.currentStreak,
+        longest: profile.longestStreak,
+        dailyGoal: profile.dailyGoal,
+        badges,
+        nextBadge,
+      },
+    },
+  });
 }

--- a/backend/src/controllers/profileController.ts
+++ b/backend/src/controllers/profileController.ts
@@ -15,10 +15,17 @@ export async function getProfileController(req: Request, res: Response) {
 
 export async function updateProfileController(req: Request, res: Response) {
   try {
-    const fields: { displayName?: string; profilePicture?: string } = {};
+    const fields: { displayName?: string; profilePicture?: string; dailyGoal?: number } = {};
 
     if (req.body.displayName !== undefined) {
       fields.displayName = req.body.displayName;
+    }
+
+    if (req.body.dailyGoal !== undefined) {
+      const goal = parseInt(req.body.dailyGoal, 10);
+      if (!isNaN(goal) && goal >= 1 && goal <= 100) {
+        fields.dailyGoal = goal;
+      }
     }
 
     if (req.file) {

--- a/backend/src/services/profileService.ts
+++ b/backend/src/services/profileService.ts
@@ -5,6 +5,9 @@ const profileSelect = {
   email: true,
   displayName: true,
   profilePicture: true,
+  dailyGoal: true,
+  currentStreak: true,
+  longestStreak: true,
   createdAt: true,
   updatedAt: true,
 };
@@ -20,7 +23,7 @@ export async function getProfile(userId: string) {
 
 export async function updateProfile(
   userId: string,
-  fields: { displayName?: string; profilePicture?: string }
+  fields: { displayName?: string; profilePicture?: string; dailyGoal?: number }
 ) {
   const user = await prisma.user.findUnique({ where: { id: userId } });
   if (!user) throw new Error("NOT_FOUND");

--- a/backend/src/services/streakService.ts
+++ b/backend/src/services/streakService.ts
@@ -1,0 +1,56 @@
+import { prisma } from "../lib/prisma";
+
+export type Badge = {
+  name: string;
+  tier: string;
+  milestone: number;
+};
+
+const BADGES: Badge[] = [
+  { name: "Shell", tier: "shell", milestone: 3 },
+  { name: "Pearl", tier: "pearl", milestone: 7 },
+  { name: "Wave", tier: "wave", milestone: 14 },
+  { name: "Anchor", tier: "anchor", milestone: 30 },
+];
+
+export function getEarnedBadges(longestStreak: number): Badge[] {
+  return BADGES.filter((b) => longestStreak >= b.milestone);
+}
+
+export function getNextBadge(longestStreak: number): Badge | null {
+  return BADGES.find((b) => longestStreak < b.milestone) ?? null;
+}
+
+function startOfDay(date: Date): Date {
+  const d = new Date(date);
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+}
+
+export async function evaluateStreak(userId: string, completionPct: number) {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) return;
+
+  const today = startOfDay(new Date());
+  const lastDate = user.lastStreakDate ? startOfDay(user.lastStreakDate) : null;
+
+  if (lastDate && lastDate.getTime() === today.getTime()) return;
+
+  if (completionPct < user.dailyGoal) return;
+
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  const isConsecutive = lastDate && lastDate.getTime() === yesterday.getTime();
+  const newStreak = isConsecutive ? user.currentStreak + 1 : 1;
+  const newLongest = Math.max(user.longestStreak, newStreak);
+
+  await prisma.user.update({
+    where: { id: userId },
+    data: {
+      currentStreak: newStreak,
+      longestStreak: newLongest,
+      lastStreakDate: today,
+    },
+  });
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -9,43 +9,74 @@ function handleSignOut() {
   window.location.href = "/login";
 }
 
+const NAV_ITEMS = [
+  { href: "/", label: "Dashboard" },
+  { href: "/tasks", label: "Tasks" },
+  { href: "/reminders", label: "Reminders" },
+  { href: "/calendar", label: "Calendar" },
+  { href: "/profile", label: "Profile" },
+];
+
 export default function Layout({ children }: { children: ReactNode }) {
   const displayName = localStorage.getItem("displayName");
   const profilePicture = localStorage.getItem("profilePicture");
   const pictureUrl = profilePicture ? `${BASE_URL}${profilePicture}` : null;
+  const path = window.location.pathname;
 
   return (
-    <div className="min-h-screen bg-ocean flex flex-col p-8">
-      <div className="w-full flex justify-end items-center gap-3 mb-4">
-        {pictureUrl ? (
-          <a href="/profile">
-            <img
-              src={pictureUrl}
-              alt="Profile"
-              className="w-8 h-8 rounded-full object-cover border border-white/30"
-            />
-          </a>
-        ) : displayName ? (
-          <a
-            href="/profile"
-            className="w-8 h-8 rounded-full bg-white/15 flex items-center justify-center text-white/70 text-sm font-bold"
+    <div className="min-h-screen bg-ocean flex">
+      <nav className="w-52 shrink-0 glass flex flex-col p-4 m-4 mr-0 rounded-xl">
+        <a href="/" className="text-lg font-bold text-white mb-6 px-2">Orbit</a>
+        <div className="flex flex-col gap-1">
+          {NAV_ITEMS.map((item) => (
+            <a
+              key={item.href}
+              href={item.href}
+              className={`text-sm px-3 py-2 rounded-lg transition-colors duration-150 ${
+                path === item.href
+                  ? "bg-white/20 text-white font-medium"
+                  : "text-white/60 hover:bg-white/10 hover:text-white"
+              }`}
+            >
+              {item.label}
+            </a>
+          ))}
+        </div>
+        <div className="mt-auto pt-4 border-t border-white/10">
+          <div className="flex items-center gap-2 px-2 mb-3">
+            {pictureUrl ? (
+              <a href="/profile">
+                <img
+                  src={pictureUrl}
+                  alt="Profile"
+                  className="w-7 h-7 rounded-full object-cover border border-white/30"
+                />
+              </a>
+            ) : displayName ? (
+              <a
+                href="/profile"
+                className="w-7 h-7 rounded-full bg-white/15 flex items-center justify-center text-white/60 text-xs font-bold"
+              >
+                {displayName.charAt(0).toUpperCase()}
+              </a>
+            ) : null}
+            {displayName && (
+              <a href="/profile" className="text-xs text-white/50 hover:text-white truncate">
+                {displayName}
+              </a>
+            )}
+          </div>
+          <button
+            onClick={handleSignOut}
+            className="w-full text-left text-sm text-white/50 px-3 py-2 rounded-lg hover:bg-white/10 hover:text-white transition-colors duration-150"
           >
-            {displayName.charAt(0).toUpperCase()}
-          </a>
-        ) : null}
-        {displayName && (
-          <a href="/profile" className="text-sm text-white/70 hover:text-white">
-            {displayName}
-          </a>
-        )}
-        <button
-          onClick={handleSignOut}
-          className="text-sm font-medium text-white/70 border border-white/20 bg-white/10 px-4 py-2 rounded-lg hover:bg-white/20 hover:text-white transition-colors duration-150"
-        >
-          Sign out
-        </button>
+            Sign out
+          </button>
+        </div>
+      </nav>
+      <div className="flex-1 flex flex-col p-8">
+        {children}
       </div>
-      {children}
     </div>
   );
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -6,6 +6,14 @@ import Card from "../components/Card";
 import Button from "../components/Button";
 
 type Weather = { temperature: number; condition: string };
+type Badge = { name: string; tier: string; milestone: number };
+type Streak = {
+  current: number;
+  longest: number;
+  dailyGoal: number;
+  badges: Badge[];
+  nextBadge: Badge | null;
+};
 type BriefingState =
   | { status: "idle" }
   | { status: "loading" }
@@ -148,6 +156,7 @@ export default function DashboardPage() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [reminders, setReminders] = useState<Reminder[]>([]);
   const [weather, setWeather] = useState<Weather | null>(null);
+  const [streak, setStreak] = useState<Streak | null>(null);
   const [loading, setLoading] = useState(true);
   const [briefing, setBriefing] = useState<BriefingState>({ status: "idle" });
   const [showWelcome, setShowWelcome] = useState(() => {
@@ -176,9 +185,10 @@ export default function DashboardPage() {
         apiFetch("/api/v1/reminders"),
       ]);
       if (dashRes.ok) {
-        const d = (await dashRes.json()) as { data: { events: Event[]; weather: Weather | null } };
+        const d = (await dashRes.json()) as { data: { events: Event[]; weather: Weather | null; streak: Streak } };
         setEvents(d.data.events);
         setWeather(d.data.weather);
+        setStreak(d.data.streak);
       }
       if (taskRes.ok) {
         const d = (await taskRes.json()) as { data: Task[] };
@@ -279,10 +289,30 @@ export default function DashboardPage() {
   return (
     <Layout>
       <div className="max-w-4xl mx-auto">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-white">Hey, {displayName}</h1>
-          <p className="text-white/50 mt-1">{todayLabel}</p>
+        <div className="mb-8 flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-white">Hey, {displayName}</h1>
+            <p className="text-white/50 mt-1">{todayLabel}</p>
+          </div>
+          <Button
+            onClick={() => void handleGetBriefing()}
+            disabled={briefing.status === "loading"}
+          >
+            {briefing.status === "loading" ? "Getting briefing…" : "Get AI Briefing"}
+          </Button>
         </div>
+
+        {briefing.status === "done" && (
+          <Card className="mb-8">
+            <p className="text-xs font-semibold text-white/40 uppercase tracking-wide mb-2">AI Briefing</p>
+            <p className="text-sm text-white/80 leading-relaxed">{briefing.text}</p>
+          </Card>
+        )}
+        {briefing.status === "error" && (
+          <Card className="mb-8">
+            <p className="text-sm text-red-300">{briefing.message}</p>
+          </Card>
+        )}
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
           {/* Weather tile */}
@@ -309,19 +339,33 @@ export default function DashboardPage() {
             </div>
           </Card>
 
-          {/* Briefing tile */}
+          {/* Streak tile */}
           <Card className="flex flex-col items-center justify-center py-6">
-            {briefing.status === "done" ? (
-              <p className="text-sm text-white/80 leading-relaxed text-center">{briefing.text}</p>
-            ) : briefing.status === "error" ? (
-              <p className="text-sm text-red-300 text-center">{briefing.message}</p>
+            {streak ? (
+              <>
+                <p className="text-3xl font-bold text-white">{streak.current}</p>
+                <p className="text-sm text-white/50 mt-1">Day streak</p>
+                {streak.badges.length > 0 && (
+                  <div className="flex gap-1.5 mt-2">
+                    {streak.badges.map((b) => (
+                      <span
+                        key={b.tier}
+                        className="text-xs bg-white/15 text-white/70 px-2 py-0.5 rounded-full"
+                        title={`${b.name} — ${b.milestone} day streak`}
+                      >
+                        {b.name}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {streak.nextBadge && (
+                  <p className="text-xs text-white/30 mt-1">
+                    {streak.nextBadge.milestone - streak.longest} days to {streak.nextBadge.name}
+                  </p>
+                )}
+              </>
             ) : (
-              <Button
-                onClick={() => void handleGetBriefing()}
-                disabled={briefing.status === "loading"}
-              >
-                {briefing.status === "loading" ? "Loading…" : "Get AI Briefing"}
-              </Button>
+              <p className="text-sm text-white/30">Loading…</p>
             )}
           </Card>
         </div>
@@ -334,7 +378,7 @@ export default function DashboardPage() {
             <div>
               <div className="flex items-center justify-between mb-3">
                 <h2 className="text-xs font-semibold text-white/50 uppercase tracking-wide">Tasks</h2>
-                <a href="/tasks" className="text-xs text-white/30 hover:text-white/60">View all</a>
+                <a href="/tasks" className="text-xs text-white/30 hover:text-white/60">View tasks</a>
               </div>
               {dueTasks.length === 0 ? (
                 <p className="text-xs text-white/30 italic">No tasks due today</p>
@@ -351,7 +395,7 @@ export default function DashboardPage() {
             <div>
               <div className="flex items-center justify-between mb-3">
                 <h2 className="text-xs font-semibold text-white/50 uppercase tracking-wide">Reminders</h2>
-                <a href="/reminders" className="text-xs text-white/30 hover:text-white/60">View all</a>
+                <a href="/reminders" className="text-xs text-white/30 hover:text-white/60">View reminders</a>
               </div>
               {todayReminders.length === 0 ? (
                 <p className="text-xs text-white/30 italic">No reminders today</p>
@@ -368,7 +412,7 @@ export default function DashboardPage() {
             <div>
               <div className="flex items-center justify-between mb-3">
                 <h2 className="text-xs font-semibold text-white/50 uppercase tracking-wide">Today&apos;s Events</h2>
-                <a href="/calendar" className="text-xs text-white/30 hover:text-white/60">View all</a>
+                <a href="/calendar" className="text-xs text-white/30 hover:text-white/60">View calendar</a>
               </div>
               {todayEvents.length === 0 ? (
                 <p className="text-xs text-white/30 italic">No events today</p>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,11 +1,16 @@
 import { useState, useEffect, useRef } from "react";
 import { apiFetch } from "../lib/api";
 import Layout from "../components/Layout";
+import Card from "../components/Card";
+import Button from "../components/Button";
 
 type Profile = {
   displayName: string;
   email: string;
   profilePicture: string | null;
+  dailyGoal: number;
+  currentStreak: number;
+  longestStreak: number;
 };
 
 const BASE_URL = (import.meta.env.VITE_API_URL as string) ?? "";
@@ -25,16 +30,10 @@ function cropToSquare(img: HTMLImageElement, zoom: number): Promise<Blob> {
   });
 }
 
-function handleSignOut() {
-  localStorage.removeItem("token");
-  localStorage.removeItem("displayName");
-  localStorage.removeItem("profilePicture");
-  window.location.href = "/login";
-}
-
 export default function ProfilePage() {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [displayName, setDisplayName] = useState("");
+  const [dailyGoal, setDailyGoal] = useState(50);
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -50,6 +49,7 @@ export default function ProfilePage() {
       .then((json: { data: Profile }) => {
         setProfile(json.data);
         setDisplayName(json.data.displayName);
+        setDailyGoal(json.data.dailyGoal);
         if (json.data.profilePicture) {
           localStorage.setItem("profilePicture", json.data.profilePicture);
         }
@@ -110,7 +110,7 @@ export default function ProfilePage() {
     cancelPreview();
   }
 
-  async function handleUpdateName(e: { preventDefault(): void }) {
+  async function handleUpdateProfile(e: { preventDefault(): void }) {
     e.preventDefault();
     setSaving(true);
     setError(null);
@@ -123,7 +123,7 @@ export default function ProfilePage() {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify({ displayName }),
+      body: JSON.stringify({ displayName, dailyGoal }),
     });
     const json = (await res.json()) as { success: boolean; data?: Profile; error?: string };
     setSaving(false);
@@ -135,7 +135,7 @@ export default function ProfilePage() {
 
     setProfile(json.data!);
     localStorage.setItem("displayName", json.data!.displayName);
-    setSuccess("Display name updated");
+    setSuccess("Profile updated");
   }
 
   if (!profile) return null;
@@ -147,19 +147,19 @@ export default function ProfilePage() {
   return (
     <Layout>
       <div className="max-w-md mx-auto mt-8">
-        <h1 className="text-2xl font-bold text-gray-900 mb-6">Profile</h1>
+        <h1 className="text-2xl font-bold text-white mb-6">Profile</h1>
 
-        {error && <p className="text-red-600 text-sm mb-4">{error}</p>}
-        {success && <p className="text-green-600 text-sm mb-4">{success}</p>}
+        {error && <p className="text-red-300 text-sm mb-4">{error}</p>}
+        {success && <p className="text-emerald-300 text-sm mb-4">{success}</p>}
 
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6">
+        <Card className="mb-6">
           {previewUrl ? (
             <div className="mb-6">
-              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
+              <p className="text-xs font-semibold text-white/50 uppercase tracking-wide mb-3">
                 Adjust & save
               </p>
               <div className="flex items-center gap-5 mb-3">
-                <div className="w-24 h-24 rounded-full overflow-hidden border border-gray-200 shrink-0">
+                <div className="w-24 h-24 rounded-full overflow-hidden border border-white/20 shrink-0">
                   <img
                     src={previewUrl}
                     alt="Preview"
@@ -169,7 +169,7 @@ export default function ProfilePage() {
                 </div>
                 <div className="flex-1">
                   <label className="flex items-center gap-3 mb-3">
-                    <span className="text-xs text-gray-500">Zoom</span>
+                    <span className="text-xs text-white/50">Zoom</span>
                     <input
                       type="range"
                       min="1"
@@ -181,41 +181,30 @@ export default function ProfilePage() {
                     />
                   </label>
                   <div className="flex gap-2">
-                    <button
-                      onClick={handleSavePicture}
-                      disabled={saving}
-                      className="bg-slate-600 text-white text-sm font-medium px-4 py-2 rounded hover:bg-slate-500 transition-colors duration-150 disabled:opacity-50"
-                    >
+                    <Button onClick={handleSavePicture} disabled={saving} className="text-xs px-3 py-1">
                       {saving ? "Saving..." : "Save"}
-                    </button>
-                    <button
-                      onClick={cancelPreview}
-                      className="border border-gray-300 bg-white text-gray-600 text-sm font-medium px-4 py-2 rounded hover:bg-gray-200 transition-colors duration-150"
-                    >
+                    </Button>
+                    <Button variant="secondary" onClick={cancelPreview} className="text-xs px-3 py-1">
                       Cancel
-                    </button>
+                    </Button>
                   </div>
                 </div>
               </div>
             </div>
           ) : (
             <div className="flex items-center gap-5 mb-6">
-              <div className="w-20 h-20 rounded-full overflow-hidden border border-gray-200 shrink-0">
+              <div className="w-20 h-20 rounded-full overflow-hidden border border-white/20 shrink-0">
                 {pictureUrl ? (
-                  <img
-                    src={pictureUrl}
-                    alt="Profile"
-                    className="w-full h-full object-cover"
-                  />
+                  <img src={pictureUrl} alt="Profile" className="w-full h-full object-cover" />
                 ) : (
-                  <div className="w-full h-full bg-gray-200 flex items-center justify-center text-gray-500 text-2xl font-bold">
+                  <div className="w-full h-full bg-white/15 flex items-center justify-center text-white/70 text-2xl font-bold">
                     {profile.displayName.charAt(0).toUpperCase()}
                   </div>
                 )}
               </div>
               <div>
                 <label className="block">
-                  <span className="text-sm font-medium text-gray-700 cursor-pointer hover:text-gray-900">
+                  <span className="text-sm font-medium text-white/70 cursor-pointer hover:text-white">
                     Upload picture
                   </span>
                   <input
@@ -226,43 +215,66 @@ export default function ProfilePage() {
                     className="hidden"
                   />
                 </label>
-                <p className="text-xs text-gray-400 mt-1">JPG, PNG, or WebP. Max 5MB.</p>
+                <p className="text-xs text-white/30 mt-1">JPG, PNG, or WebP. Max 5MB.</p>
               </div>
             </div>
           )}
 
           <div className="mb-4">
-            <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Email</span>
-            <p className="text-sm text-gray-900 mt-1">{profile.email}</p>
+            <span className="text-xs font-semibold text-white/50 uppercase tracking-wide">Email</span>
+            <p className="text-sm text-white mt-1">{profile.email}</p>
           </div>
 
-          <form onSubmit={handleUpdateName}>
+          <form onSubmit={handleUpdateProfile}>
             <label className="block mb-4">
-              <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Display Name</span>
+              <span className="text-xs font-semibold text-white/50 uppercase tracking-wide">Display Name</span>
               <input
                 type="text"
                 value={displayName}
                 onChange={(e) => setDisplayName(e.target.value)}
                 required
-                className="mt-1 block w-full border border-gray-300 rounded px-3 py-2 text-sm"
+                className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40"
               />
             </label>
-            <button
-              type="submit"
-              disabled={saving}
-              className="w-full bg-slate-600 text-white text-sm font-medium px-4 py-3 rounded hover:bg-slate-500 transition-colors duration-150 disabled:opacity-50"
-            >
+            <label className="block mb-4">
+              <span className="text-xs font-semibold text-white/50 uppercase tracking-wide">
+                Daily completion goal
+              </span>
+              <div className="flex items-center gap-3 mt-1">
+                <input
+                  type="range"
+                  min="10"
+                  max="100"
+                  step="10"
+                  value={dailyGoal}
+                  onChange={(e) => setDailyGoal(parseInt(e.target.value, 10))}
+                  className="flex-1"
+                />
+                <span className="text-sm text-white font-medium w-12 text-right">{dailyGoal}%</span>
+              </div>
+              <p className="text-xs text-white/30 mt-1">
+                Meet this daily to keep your streak going
+              </p>
+            </label>
+            <Button type="submit" disabled={saving} className="w-full py-3">
               {saving ? "Saving..." : "Save"}
-            </button>
+            </Button>
           </form>
-        </div>
+        </Card>
 
-        <button
-          onClick={handleSignOut}
-          className="w-full border border-gray-300 bg-white text-gray-600 text-sm font-medium px-4 py-3 rounded hover:bg-gray-200 transition-colors duration-150"
-        >
-          Sign out
-        </button>
+        <Card className="mb-6">
+          <p className="text-xs font-semibold text-white/50 uppercase tracking-wide mb-3">Streak</p>
+          <div className="flex gap-6">
+            <div>
+              <p className="text-2xl font-bold text-white">{profile.currentStreak}</p>
+              <p className="text-xs text-white/40">Current</p>
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-white">{profile.longestStreak}</p>
+              <p className="text-xs text-white/40">Longest</p>
+            </div>
+          </div>
+        </Card>
       </div>
     </Layout>
   );


### PR DESCRIPTION
Add a persistent sidebar nav across all pages and a daily-goal streak system with ocean-themed badges.

Sidebar:
- Consistent glass sidebar on every page with Orbit branding, nav links (Dashboard, Tasks, Reminders, Calendar, Profile) with active state highlighting, user avatar + display name at the bottom, and sign out
- Replaces the previous header-only layout and conditional sidebar

Streak system (backend):
- Added dailyGoal (default 50%), currentStreak, longestStreak, and lastStreakDate fields to User model with migration
- streakService evaluates completion % against the user's daily goal on each dashboard load — increments streak on consecutive days, resets when a day is missed
- Ocean-themed badge tiers unlock at milestones: Shell (3 days), Pearl (7), Wave (14), Anchor (30)
- Dashboard endpoint returns streak data (current, longest, dailyGoal, earned badges, next badge) alongside existing summary

Profile page:
- Daily completion goal slider (10-100%, step 10) saved via PATCH /api/v1/profile with dailyGoal field
- Streak stats (current and longest) displayed in a dedicated card
- Fully themed to ocean design system (was still using old gray theme)

Dashboard:
- Streak tile in top row showing current streak count, earned badge pills, and progress to next badge
- AI briefing button moved to header row; briefing text renders as a full-width card below the header instead of replacing a tile
- "View all" links renamed to specific destinations (View tasks, View reminders, View calendar)