### PR TITLE
fix(frontend): M7 cleanup - nav order, account settings, and clearing…

### DIFF
--- a/backend/src/controllers/profileController.ts
+++ b/backend/src/controllers/profileController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { getProfile, updateProfile } from "../services/profileService";
+import { getProfile, updateProfile, changePassword } from "../services/profileService";
 
 export async function getProfileController(req: Request, res: Response) {
   try {
@@ -15,10 +15,14 @@ export async function getProfileController(req: Request, res: Response) {
 
 export async function updateProfileController(req: Request, res: Response) {
   try {
-    const fields: { displayName?: string; profilePicture?: string; dailyGoal?: number } = {};
+    const fields: { displayName?: string; profilePicture?: string; dailyGoal?: number; email?: string } = {};
 
     if (req.body.displayName !== undefined) {
       fields.displayName = req.body.displayName;
+    }
+
+    if (req.body.email !== undefined) {
+      fields.email = req.body.email;
     }
 
     if (req.body.dailyGoal !== undefined) {
@@ -37,6 +41,28 @@ export async function updateProfileController(req: Request, res: Response) {
   } catch (err: unknown) {
     if (err instanceof Error && err.message === "NOT_FOUND") {
       return res.status(404).json({ success: false, error: "Profile not found" });
+    }
+    throw err;
+  }
+}
+
+export async function changePasswordController(req: Request, res: Response) {
+  try {
+    const { currentPassword, newPassword } = req.body;
+    if (!currentPassword || !newPassword) {
+      return res.status(400).json({ success: false, error: "Current and new password are required" });
+    }
+    if (newPassword.length < 6) {
+      return res.status(400).json({ success: false, error: "New password must be at least 6 characters" });
+    }
+    await changePassword(req.userId!, currentPassword, newPassword);
+    res.json({ success: true });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "NOT_FOUND") {
+      return res.status(404).json({ success: false, error: "Profile not found" });
+    }
+    if (err instanceof Error && err.message === "INVALID_PASSWORD") {
+      return res.status(400).json({ success: false, error: "Current password is incorrect" });
     }
     throw err;
   }

--- a/backend/src/routes/profile.ts
+++ b/backend/src/routes/profile.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 import {
   getProfileController,
   updateProfileController,
+  changePasswordController,
 } from "../controllers/profileController";
 
 const uploadsDir = path.join(__dirname, "../../uploads");
@@ -37,5 +38,6 @@ const router = Router();
 
 router.get("/", getProfileController);
 router.patch("/", upload.single("profilePicture"), updateProfileController);
+router.post("/password", changePasswordController);
 
 export default router;

--- a/backend/src/services/profileService.ts
+++ b/backend/src/services/profileService.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../lib/prisma";
+import { hashPassword, verifyPassword } from "../lib/password";
 
 const profileSelect = {
   id: true,
@@ -23,7 +24,7 @@ export async function getProfile(userId: string) {
 
 export async function updateProfile(
   userId: string,
-  fields: { displayName?: string; profilePicture?: string; dailyGoal?: number }
+  fields: { displayName?: string; profilePicture?: string; dailyGoal?: number; email?: string }
 ) {
   const user = await prisma.user.findUnique({ where: { id: userId } });
   if (!user) throw new Error("NOT_FOUND");
@@ -32,4 +33,19 @@ export async function updateProfile(
     data: fields,
     select: profileSelect,
   });
+}
+
+export async function changePassword(
+  userId: string,
+  currentPassword: string,
+  newPassword: string
+) {
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new Error("NOT_FOUND");
+
+  const valid = await verifyPassword(currentPassword, user.passwordHash);
+  if (!valid) throw new Error("INVALID_PASSWORD");
+
+  const passwordHash = await hashPassword(newPassword);
+  await prisma.user.update({ where: { id: userId }, data: { passwordHash } });
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,9 +11,9 @@ function handleSignOut() {
 
 const NAV_ITEMS = [
   { href: "/", label: "Dashboard" },
+  { href: "/calendar", label: "Calendar" },
   { href: "/tasks", label: "Tasks" },
   { href: "/reminders", label: "Reminders" },
-  { href: "/calendar", label: "Calendar" },
   { href: "/profile", label: "Profile" },
 ];
 

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -710,7 +710,9 @@ export default function CalendarPage() {
         <TimeGrid days={getWeekDays()} events={events} tasks={tasks} reminders={reminders} onSlotClick={openCreate} onEventClick={(event) => setModal({ mode: "edit", event })} onReminderClick={setReminderModal} onTaskClick={setTaskModal} />
       )}
       {view === "day" && (
-        <TimeGrid days={[cursor]} events={events} tasks={tasks} reminders={reminders} onSlotClick={openCreate} onEventClick={(event) => setModal({ mode: "edit", event })} onReminderClick={setReminderModal} onTaskClick={setTaskModal} />
+        <div className="max-w-xl">
+          <TimeGrid days={[cursor]} events={events} tasks={tasks} reminders={reminders} onSlotClick={openCreate} onEventClick={(event) => setModal({ mode: "edit", event })} onReminderClick={setReminderModal} onTaskClick={setTaskModal} />
+        </div>
       )}
 
       {modal && (

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -33,10 +33,17 @@ function cropToSquare(img: HTMLImageElement, zoom: number): Promise<Blob> {
 export default function ProfilePage() {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [displayName, setDisplayName] = useState("");
+  const [email, setEmail] = useState("");
   const [dailyGoal, setDailyGoal] = useState(50);
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [passwordSaving, setPasswordSaving] = useState(false);
+  const [passwordSuccess, setPasswordSuccess] = useState<string | null>(null);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
 
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [previewZoom, setPreviewZoom] = useState(1);
@@ -49,6 +56,7 @@ export default function ProfilePage() {
       .then((json: { data: Profile }) => {
         setProfile(json.data);
         setDisplayName(json.data.displayName);
+        setEmail(json.data.email);
         setDailyGoal(json.data.dailyGoal);
         if (json.data.profilePicture) {
           localStorage.setItem("profilePicture", json.data.profilePicture);
@@ -123,7 +131,7 @@ export default function ProfilePage() {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify({ displayName, dailyGoal }),
+      body: JSON.stringify({ displayName, email, dailyGoal }),
     });
     const json = (await res.json()) as { success: boolean; data?: Profile; error?: string };
     setSaving(false);
@@ -138,6 +146,29 @@ export default function ProfilePage() {
     setSuccess("Profile updated");
   }
 
+  async function handleChangePassword(e: { preventDefault(): void }) {
+    e.preventDefault();
+    setPasswordSaving(true);
+    setPasswordError(null);
+    setPasswordSuccess(null);
+
+    const res = await apiFetch("/api/v1/profile/password", {
+      method: "POST",
+      body: JSON.stringify({ currentPassword, newPassword }),
+    });
+    const json = (await res.json()) as { success: boolean; error?: string };
+    setPasswordSaving(false);
+
+    if (!res.ok) {
+      setPasswordError(json.error ?? "Failed to change password");
+      return;
+    }
+
+    setCurrentPassword("");
+    setNewPassword("");
+    setPasswordSuccess("Password changed");
+  }
+
   if (!profile) return null;
 
   const pictureUrl = profile.profilePicture
@@ -146,13 +177,15 @@ export default function ProfilePage() {
 
   return (
     <Layout>
-      <div className="max-w-md mx-auto mt-8">
+      <div className="w-full mt-4">
         <h1 className="text-2xl font-bold text-white mb-6">Profile</h1>
 
         {error && <p className="text-red-300 text-sm mb-4">{error}</p>}
         {success && <p className="text-emerald-300 text-sm mb-4">{success}</p>}
 
-        <Card className="mb-6">
+        <div className="grid grid-cols-1 md:grid-cols-[1fr_1fr_auto] gap-6">
+
+        <Card>
           {previewUrl ? (
             <div className="mb-6">
               <p className="text-xs font-semibold text-white/50 uppercase tracking-wide mb-3">
@@ -220,12 +253,17 @@ export default function ProfilePage() {
             </div>
           )}
 
-          <div className="mb-4">
-            <span className="text-xs font-semibold text-white/50 uppercase tracking-wide">Email</span>
-            <p className="text-sm text-white mt-1">{profile.email}</p>
-          </div>
-
           <form onSubmit={handleUpdateProfile}>
+            <label className="block mb-4">
+              <span className="text-xs font-semibold text-white/50 uppercase tracking-wide">Email</span>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40"
+              />
+            </label>
             <label className="block mb-4">
               <span className="text-xs font-semibold text-white/50 uppercase tracking-wide">Display Name</span>
               <input
@@ -262,53 +300,69 @@ export default function ProfilePage() {
           </form>
         </Card>
 
-        <Card className="mb-6">
-          <p className="text-xs font-semibold text-white/50 uppercase tracking-wide mb-3">Streak</p>
-          <div className="flex gap-6 mb-4">
+        <Card>
+          <p className="text-xs font-semibold text-white/50 uppercase tracking-wide mb-3">Change Password</p>
+          {passwordError && <p className="text-red-300 text-sm mb-3">{passwordError}</p>}
+          {passwordSuccess && <p className="text-emerald-300 text-sm mb-3">{passwordSuccess}</p>}
+          <form onSubmit={handleChangePassword}>
+            <label className="block mb-3">
+              <span className="text-xs text-white/50">Current password</span>
+              <input
+                type="password"
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                required
+                className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40"
+              />
+            </label>
+            <label className="block mb-4">
+              <span className="text-xs text-white/50">New password</span>
+              <input
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                required
+                minLength={6}
+                className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40"
+              />
+            </label>
+            <Button type="submit" disabled={passwordSaving} className="w-full py-2.5">
+              {passwordSaving ? "Changing..." : "Change password"}
+            </Button>
+          </form>
+        </Card>
+
+        <Card className="w-48">
+          <p className="text-[10px] font-semibold text-white/40 uppercase tracking-wide mb-2">Streak</p>
+          <div className="flex gap-4 mb-3">
             <div>
-              <p className="text-2xl font-bold text-white">{profile.currentStreak}</p>
-              <p className="text-xs text-white/40">Current</p>
+              <p className="text-lg font-bold text-white">{profile.currentStreak}</p>
+              <p className="text-[10px] text-white/40">Current</p>
             </div>
             <div>
-              <p className="text-2xl font-bold text-white">{profile.longestStreak}</p>
-              <p className="text-xs text-white/40">Longest</p>
+              <p className="text-lg font-bold text-white">{profile.longestStreak}</p>
+              <p className="text-[10px] text-white/40">Longest</p>
             </div>
           </div>
-          <div className="border-t border-white/10 pt-3">
-            <p className="text-xs font-semibold text-white/50 uppercase tracking-wide mb-2">Badges</p>
-            <p className="text-xs text-white/30 mb-2">Hit your daily goal on consecutive days to unlock ocean-themed badges.</p>
-            <div className="flex flex-col gap-2.5">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <span className={`text-base ${profile.longestStreak >= 3 ? "" : "opacity-30"}`}>🐚</span>
-                  <span className="text-xs text-white/70">Shell</span>
+          <div className="border-t border-white/10 pt-2">
+            <div className="flex flex-col gap-1.5">
+              {[
+                { icon: "🐚", name: "Shell", milestone: 3 },
+                { icon: "🦪", name: "Pearl", milestone: 7 },
+                { icon: "🌊", name: "Wave", milestone: 14 },
+                { icon: "⚓", name: "Anchor", milestone: 30 },
+              ].map((b) => (
+                <div key={b.name} className="flex items-center gap-1.5">
+                  <span className={`text-xs ${profile.longestStreak >= b.milestone ? "" : "opacity-30"}`}>{b.icon}</span>
+                  <span className={`text-[10px] ${profile.longestStreak >= b.milestone ? "text-white/60" : "text-white/25"}`}>{b.name}</span>
+                  {profile.longestStreak < b.milestone && <span className="text-[10px] text-white/20 ml-auto">{b.milestone}d</span>}
                 </div>
-                <span className={`text-xs ${profile.longestStreak >= 3 ? "text-emerald-400" : "text-white/30"}`}>{profile.longestStreak >= 3 ? "Unlocked" : "3 day streak"}</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <span className={`text-base ${profile.longestStreak >= 7 ? "" : "opacity-30"}`}>🦪</span>
-                  <span className="text-xs text-white/70">Pearl</span>
-                </div>
-                <span className={`text-xs ${profile.longestStreak >= 7 ? "text-emerald-400" : "text-white/30"}`}>{profile.longestStreak >= 7 ? "Unlocked" : "7 day streak"}</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <span className={`text-base ${profile.longestStreak >= 14 ? "" : "opacity-30"}`}>🌊</span>
-                  <span className="text-xs text-white/70">Wave</span>
-                </div>
-                <span className={`text-xs ${profile.longestStreak >= 14 ? "text-emerald-400" : "text-white/30"}`}>{profile.longestStreak >= 14 ? "Unlocked" : "14 day streak"}</span>
-              </div>
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <span className={`text-base ${profile.longestStreak >= 30 ? "" : "opacity-30"}`}>⚓</span>
-                  <span className="text-xs text-white/70">Anchor</span>
-                </div>
-                <span className={`text-xs ${profile.longestStreak >= 30 ? "text-emerald-400" : "text-white/30"}`}>{profile.longestStreak >= 30 ? "Unlocked" : "30 day streak"}</span>
-              </div>
+              ))}
             </div>
+            <p className="text-[9px] text-white/20 mt-2">Keep your streak alive to collect these.</p>
           </div>
         </Card>
+        </div>
       </div>
     </Layout>
   );

--- a/frontend/src/pages/RemindersPage.tsx
+++ b/frontend/src/pages/RemindersPage.tsx
@@ -136,16 +136,19 @@ function CreateCard({ onRefresh }: { onRefresh: () => Promise<void> }) {
 
   if (!open) {
     return (
-      <div onClick={() => setOpen(true)} className="cursor-pointer">
-        <Card className="mb-6 hover:bg-white/15 transition-colors">
-          <p className="text-sm text-white/40 text-center">+ New reminder</p>
-        </Card>
+      <div className="mb-6">
+        <button
+          onClick={() => setOpen(true)}
+          className="text-xs text-white/40 hover:text-white/70 bg-white/5 hover:bg-white/10 border border-white/10 px-3 py-1.5 rounded-lg transition-colors duration-150"
+        >
+          + New reminder
+        </button>
       </div>
     );
   }
 
   return (
-    <Card className="mb-6">
+    <Card className="mb-6 max-w-sm">
       <p className="text-xs font-semibold text-white/50 uppercase tracking-wide mb-3">New Reminder</p>
       {error && <p className="text-red-300 text-sm mb-3">{error}</p>}
       <label className="block mb-2">
@@ -216,6 +219,12 @@ export default function RemindersPage() {
     }, 30000);
     return () => clearInterval(interval);
   }, []);
+
+  async function handleClearCompleted() {
+    const completedReminders = reminders.filter((r) => r.status === "COMPLETED" && r.repeatFrequency === "NONE");
+    await Promise.all(completedReminders.map((r) => apiFetch(`/api/v1/reminders/${r.id}`, { method: "DELETE" })));
+    await fetchReminders();
+  }
 
   function handleDeleted(reminder: Reminder) {
     setRecentlyDeleted((prev) => [reminder, ...prev].slice(0, 5));
@@ -288,12 +297,15 @@ export default function RemindersPage() {
 
         {showCompleted && completed.length > 0 && (
           <div className="mt-8">
-            <h2 className="text-xs font-semibold text-white/50 uppercase tracking-wide mb-3">Completed</h2>
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-xs font-semibold text-white/50 uppercase tracking-wide">Completed</h2>
+              <button onClick={handleClearCompleted} className="text-xs text-white/30 hover:text-white/60 transition-colors duration-150">Clear all</button>
+            </div>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
               {completed.map((r) => (
                 <Card key={r.id} className="opacity-60">
-                  <div className="flex items-center gap-2">
-                    <span className="text-emerald-400 text-sm">✓</span>
+                  <div className="flex items-center gap-3">
+                    <span className="w-4 h-4 rounded bg-emerald-400/30 border border-emerald-400/50 shrink-0 flex items-center justify-center text-emerald-400 text-[10px]">✓</span>
                     <p className="text-white/50 text-sm truncate line-through">{r.title}</p>
                     <span className="text-[10px] bg-white/10 text-white/30 px-1.5 py-0.5 rounded shrink-0 ml-auto">
                       {REPEAT_LABELS[r.repeatFrequency]}

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -42,6 +42,14 @@ function TaskCard({
     }
   }
 
+  async function handleRepeat() {
+    const res = await apiFetch("/api/v1/tasks", {
+      method: "POST",
+      body: JSON.stringify({ title: task.title, dueDate: task.dueDate ? task.dueDate.slice(0, 10) : undefined }),
+    });
+    if (res.ok) await onRefresh();
+  }
+
   async function handleEdit(e: FormEvent) {
     e.preventDefault();
     const res = await apiFetch(`/api/v1/tasks/${task.id}`, {
@@ -106,9 +114,18 @@ function TaskCard({
 
   return (
     <Card className="mb-2">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <p className="text-white font-medium truncate">{task.title}</p>
+      <div className="flex items-start gap-3">
+        {task.status === "UPCOMING" ? (
+          <button
+            onClick={handleComplete}
+            className="mt-0.5 w-4 h-4 rounded border border-white/30 shrink-0 hover:bg-white/20 transition-colors"
+            aria-label="Complete task"
+          />
+        ) : (
+          <span className="mt-0.5 w-4 h-4 rounded bg-emerald-400/30 border border-emerald-400/50 shrink-0 flex items-center justify-center text-emerald-400 text-[10px]">✓</span>
+        )}
+        <div className="flex-1 min-w-0 cursor-pointer" onClick={openEdit}>
+          <p className={`text-white font-medium truncate ${task.status === "COMPLETED" ? "line-through text-white/50" : ""}`}>{task.title}</p>
           {task.description && <p className="text-xs text-white/50 mt-0.5">{task.description}</p>}
           {task.dueDate && (
             <p className="text-xs text-white/40 mt-0.5">
@@ -117,42 +134,13 @@ function TaskCard({
           )}
         </div>
         <div className="flex items-center gap-1 shrink-0">
-          {task.status === "UPCOMING" && (
-            <button onClick={handleComplete} title="Mark complete" className="text-emerald-400 hover:text-emerald-300 px-1.5 py-1 rounded hover:bg-white/10 transition-colors duration-150 text-base leading-none">✓</button>
+          {task.status === "COMPLETED" && (
+            <button onClick={handleRepeat} title="Repeat task" className="text-white/40 hover:text-white px-1.5 py-1 rounded hover:bg-white/10 transition-colors duration-150 text-xs leading-none">↻</button>
           )}
           <button onClick={handleDelete} title="Delete" className="text-red-400 hover:text-red-300 px-1.5 py-1 rounded hover:bg-white/10 transition-colors duration-150 text-base leading-none">✕</button>
-          <button onClick={openEdit} title="Edit" className="text-white/40 hover:text-white px-1.5 py-1 rounded hover:bg-white/10 transition-colors duration-150 text-base leading-none tracking-tighter">···</button>
         </div>
       </div>
     </Card>
-  );
-}
-
-function Section({
-  title,
-  tasks,
-  onRefresh,
-  onDeleted,
-  alwaysShow = false,
-}: {
-  title: string;
-  tasks: Task[];
-  onRefresh: () => Promise<void>;
-  onDeleted: (task: Task) => void;
-  alwaysShow?: boolean;
-}) {
-  if (tasks.length === 0 && !alwaysShow) return null;
-  return (
-    <div className="mb-8">
-      <h2 className="text-xs font-semibold text-white/50 uppercase tracking-wide mb-3">{title}</h2>
-      {tasks.length === 0 ? (
-        <p className="text-xs text-white/30 italic">Nothing here yet.</p>
-      ) : (
-        tasks.map((task) => (
-          <TaskCard key={task.id} task={task} onRefresh={onRefresh} onDeleted={onDeleted} />
-        ))
-      )}
-    </div>
   );
 }
 
@@ -160,7 +148,9 @@ export default function TasksPage() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [recentlyDeleted, setRecentlyDeleted] = useState<Task[]>([]);
   const [showForm, setShowForm] = useState(false);
+  const [showCompleted, setShowCompleted] = useState(false);
   const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [error, setError] = useState<string | null>(null);
 
@@ -181,6 +171,12 @@ export default function TasksPage() {
       setRecentlyDeleted((prev) => prev.filter((t) => t.id !== task.id));
       await fetchTasks();
     }
+  }
+
+  async function handleClearCompleted() {
+    const completedTasks = tasks.filter((t) => t.status === "COMPLETED");
+    await Promise.all(completedTasks.map((t) => apiFetch(`/api/v1/tasks/${t.id}`, { method: "DELETE" })));
+    await fetchTasks();
   }
 
   async function fetchTasks() {
@@ -205,7 +201,7 @@ export default function TasksPage() {
     setError(null);
     const res = await apiFetch("/api/v1/tasks", {
       method: "POST",
-      body: JSON.stringify({ title, dueDate: dueDate || undefined }),
+      body: JSON.stringify({ title, description: description || undefined, dueDate: dueDate || undefined }),
     });
     const data = (await res.json()) as { error?: string };
     if (!res.ok) {
@@ -213,6 +209,7 @@ export default function TasksPage() {
       return;
     }
     setTitle("");
+    setDescription("");
     setDueDate("");
     setShowForm(false);
     await fetchTasks();
@@ -229,56 +226,97 @@ export default function TasksPage() {
   const backlog = tasks.filter((t) => t.status === "UPCOMING" && !t.dueDate);
   const completed = tasks.filter((t) => t.status === "COMPLETED");
 
+  const inputClass = "mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40";
+
   return (
     <Layout>
-      <div className="flex flex-col items-center">
-        <div className="w-full max-w-md flex justify-between items-center mb-8">
+      <div className="w-full">
+        <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-bold text-white">Tasks</h1>
-          <Button variant="secondary" onClick={() => setShowForm((v) => !v)}>
-            {showForm ? "Cancel" : "+ Add task"}
-          </Button>
-        </div>
-
-        {showForm && (
-          <Card className="w-full max-w-md mb-8">
-            <form onSubmit={handleCreate}>
-              {error && <p className="text-red-300 text-sm mb-3">{error}</p>}
-              <label className="block mb-3">
-                <span className="text-sm font-medium text-white/70">Title</span>
-                <input
-                  type="text"
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                  required
-                  autoFocus
-                  className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40"
-                />
-              </label>
-              <label className="block mb-4">
-                <span className="text-sm font-medium text-white/70">
-                  Due date <span className="text-white/30">(optional)</span>
-                </span>
-                <input
-                  type="date"
-                  value={dueDate}
-                  onChange={(e) => setDueDate(e.target.value)}
-                  className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40"
-                />
-              </label>
-              <Button type="submit" className="w-full py-2.5">Save task</Button>
-            </form>
-          </Card>
-        )}
-
-        <div className="w-full max-w-md">
-          <Section title="Overdue" tasks={overdue} onRefresh={fetchTasks} onDeleted={handleDeleted} />
-          <Section title="Upcoming" tasks={upcoming} onRefresh={fetchTasks} onDeleted={handleDeleted} />
-          <Section title="Backlog" tasks={backlog} onRefresh={fetchTasks} onDeleted={handleDeleted} />
-          <Section title="Completed" tasks={completed} onRefresh={fetchTasks} onDeleted={handleDeleted} alwaysShow />
-          {tasks.length === 0 && !showForm && (
-            <p className="text-sm text-white/40 text-center">No tasks yet.</p>
+          {completed.length > 0 && (
+            <button
+              onClick={() => setShowCompleted((v) => !v)}
+              className="text-xs font-semibold text-white/30 uppercase tracking-wide hover:text-white/50 transition-colors duration-150"
+            >
+              Completed ({completed.length}) {showCompleted ? "▾" : "▸"}
+            </button>
           )}
         </div>
+
+        {showForm ? (
+          <Card className="mb-6 max-w-sm">
+            <p className="text-xs font-semibold text-white/50 uppercase tracking-wide mb-3">New Task</p>
+            {error && <p className="text-red-300 text-sm mb-3">{error}</p>}
+            <form onSubmit={handleCreate}>
+              <label className="block mb-2">
+                <span className="text-xs text-white/50">Title</span>
+                <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} required autoFocus className={inputClass} />
+              </label>
+              <label className="block mb-2">
+                <span className="text-xs text-white/50">Description <span className="text-white/30">(optional)</span></span>
+                <input type="text" value={description} onChange={(e) => setDescription(e.target.value)} className={inputClass} />
+              </label>
+              <label className="block mb-3">
+                <span className="text-xs text-white/50">Due date <span className="text-white/30">(optional)</span></span>
+                <input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} className={inputClass} />
+              </label>
+              <div className="flex gap-2">
+                <Button type="submit" className="text-xs px-3 py-1.5">Save</Button>
+                <Button variant="secondary" type="button" onClick={() => setShowForm(false)} className="text-xs px-3 py-1.5">Cancel</Button>
+              </div>
+            </form>
+          </Card>
+        ) : (
+          <div className="mb-6">
+            <button
+              onClick={() => setShowForm(true)}
+              className="text-xs text-white/40 hover:text-white/70 bg-white/5 hover:bg-white/10 border border-white/10 px-3 py-1.5 rounded-lg transition-colors duration-150"
+            >
+              + New task
+            </button>
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div>
+            <h2 className="text-xs font-semibold text-white/50 uppercase tracking-wide mb-3">Overdue</h2>
+            {overdue.length === 0 ? (
+              <p className="text-xs text-white/30 italic">Nothing overdue.</p>
+            ) : overdue.map((t) => (
+              <TaskCard key={t.id} task={t} onRefresh={fetchTasks} onDeleted={handleDeleted} />
+            ))}
+          </div>
+          <div>
+            <h2 className="text-xs font-semibold text-white/50 uppercase tracking-wide mb-3">Upcoming</h2>
+            {upcoming.length === 0 ? (
+              <p className="text-xs text-white/30 italic">Nothing upcoming.</p>
+            ) : upcoming.map((t) => (
+              <TaskCard key={t.id} task={t} onRefresh={fetchTasks} onDeleted={handleDeleted} />
+            ))}
+          </div>
+          <div>
+            <h2 className="text-xs font-semibold text-white/50 uppercase tracking-wide mb-3">Backlog</h2>
+            {backlog.length === 0 ? (
+              <p className="text-xs text-white/30 italic">No backlog tasks.</p>
+            ) : backlog.map((t) => (
+              <TaskCard key={t.id} task={t} onRefresh={fetchTasks} onDeleted={handleDeleted} />
+            ))}
+          </div>
+        </div>
+
+        {showCompleted && completed.length > 0 && (
+          <div className="mt-8">
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-xs font-semibold text-white/50 uppercase tracking-wide">Completed</h2>
+              <button onClick={handleClearCompleted} className="text-xs text-white/30 hover:text-white/60 transition-colors duration-150">Clear all</button>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+              {completed.map((t) => (
+                <TaskCard key={t.id} task={t} onRefresh={fetchTasks} onDeleted={handleDeleted} />
+              ))}
+            </div>
+          </div>
+        )}
       </div>
 
       {recentlyDeleted.length > 0 && (
@@ -288,7 +326,6 @@ export default function TasksPage() {
             <div key={task.id} className="flex items-center justify-between bg-white/5 border border-white/10 rounded-lg px-4 py-3 mb-2">
               <div className="min-w-0">
                 <p className="text-sm text-white/50 truncate">{task.title}</p>
-                {task.description && <p className="text-xs text-white/30 truncate">{task.description}</p>}
               </div>
               <Button variant="secondary" onClick={() => handleRestore(task)} className="text-xs px-2 py-1 ml-3 shrink-0">Restore</Button>
             </div>


### PR DESCRIPTION
… completed items (#123)

Sidebar:
- Calendar moved directly under Dashboard in nav order

Profile:
- All three cards in a single row — profile/settings and password change at equal width, streak/badges in a compact column on the right with smaller text and condensed badge list
- Email is now editable (was read-only)
- Password change card with current password confirmation, 6-char minimum. Backend adds POST /api/v1/profile/password endpoint
- Badge legend description at bottom in tiny text

Tasks page:
- Restructured to match Reminders layout: full-width 3-column grid (Overdue / Upcoming / Backlog), small "+ New task" button that expands into inline create form with description field
- Uniform checkbox pattern: empty bordered square for upcoming, filled emerald square with checkmark for completed
- Completed section collapsed by default with toggle and "Clear all"
- Repeat button (↻) on completed tasks to create a new copy, replaces the edit button which served no purpose on completed items

Reminders page:
- Create form constrained to max-w-sm to match task create size
- Completed section has "Clear all" button (deletes non-repeating completed reminders)
- Completed items use uniform filled checkbox style

Calendar:
- Day view constrained to max-w-xl for better readability