### PR TITLE
fix(frontend/backend): post-M7 bug fixes and polish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,8 @@ VITE_API_URL=http://localhost:3000
 
 # Allowed frontend origin for CORS (set to the deployed frontend URL in staging/prod)
 CORS_ORIGIN=http://localhost:5173
+
+# Weather location for the dashboard widget (uses Open-Meteo — no API key required)
+# Format: "latitude,longitude" — e.g. New York: "40.7128,-74.0060"
+# Leave unset to disable weather display
+WEATHER_LOCATION="40.7128,-74.0060"

--- a/backend/src/controllers/briefingController.ts
+++ b/backend/src/controllers/briefingController.ts
@@ -6,14 +6,11 @@ export async function getBriefingController(req: Request, res: Response) {
     return res.status(503).json({ success: false, error: "AI briefing is not configured" });
   }
 
-  const { lat, lon, localTime, timezone } = req.body as {
-    lat?: number;
-    lon?: number;
+  const { localTime, timezone } = req.body as {
     localTime?: string;
     timezone?: string;
   };
-  const coords = typeof lat === "number" && typeof lon === "number" ? { lat, lon } : undefined;
 
-  const briefing = await generateBriefing(req.userId!, coords, { localTime, timezone });
+  const briefing = await generateBriefing(req.userId!, { localTime, timezone });
   res.json({ success: true, data: { briefing } });
 }

--- a/backend/src/controllers/dashboardController.ts
+++ b/backend/src/controllers/dashboardController.ts
@@ -4,11 +4,7 @@ import { evaluateStreak, getEarnedBadges, getNextBadge } from "../services/strea
 import { getProfile } from "../services/profileService";
 
 export async function getDashboardController(req: Request, res: Response) {
-  const lat = parseFloat(req.query.lat as string);
-  const lon = parseFloat(req.query.lon as string);
-  const coords = !isNaN(lat) && !isNaN(lon) ? { lat, lon } : undefined;
-
-  const data = await getDashboardSummary(req.userId!, coords);
+  const data = await getDashboardSummary(req.userId!);
 
   const totalItems = data.tasks.length + data.reminders.length;
   const completed = data.tasks.filter((t) => t.status === "COMPLETED").length

--- a/backend/src/services/briefingService.ts
+++ b/backend/src/services/briefingService.ts
@@ -1,12 +1,11 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { prisma } from "../lib/prisma";
-import { getWeather } from "./weatherService";
+import { getWeatherFromEnv } from "./weatherService";
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
 export async function generateBriefing(
   userId: string,
-  coords?: { lat: number; lon: number },
   timeContext?: { localTime?: string; timezone?: string }
 ): Promise<string> {
   const now = new Date();
@@ -27,7 +26,7 @@ export async function generateBriefing(
       where: { userId, status: "UPCOMING", scheduledAt: { lte: weekEnd, gte: now } },
       orderBy: { scheduledAt: "asc" },
     }),
-    coords ? getWeather(coords.lat, coords.lon) : Promise.resolve(null),
+    getWeatherFromEnv(),
   ]);
 
   const tz = timeContext?.timezone;

--- a/backend/src/services/dashboardService.ts
+++ b/backend/src/services/dashboardService.ts
@@ -1,7 +1,7 @@
 import { prisma } from "../lib/prisma";
-import { getWeather } from "./weatherService";
+import { getWeatherFromEnv } from "./weatherService";
 
-export async function getDashboardSummary(userId: string, coords?: { lat: number; lon: number }) {
+export async function getDashboardSummary(userId: string) {
   const now = new Date();
   const todayStart = new Date(now);
   todayStart.setHours(0, 0, 0, 0);
@@ -19,7 +19,7 @@ export async function getDashboardSummary(userId: string, coords?: { lat: number
     prisma.reminder.findMany({
       where: { userId, status: "UPCOMING", scheduledAt: { gte: todayStart, lte: todayEnd } },
     }),
-    coords ? getWeather(coords.lat, coords.lon) : Promise.resolve(null),
+    getWeatherFromEnv(),
   ]);
 
   return { events, tasks, reminders, weather };

--- a/backend/src/services/weatherService.ts
+++ b/backend/src/services/weatherService.ts
@@ -30,6 +30,16 @@ const WMO_DESCRIPTIONS: Record<number, string> = {
   99: "thunderstorm with heavy hail",
 };
 
+export function getWeatherFromEnv(): Promise<Weather | null> {
+  const loc = process.env.WEATHER_LOCATION;
+  if (!loc) return Promise.resolve(null);
+  const [latStr, lonStr] = loc.split(",");
+  const lat = parseFloat(latStr);
+  const lon = parseFloat(lonStr);
+  if (isNaN(lat) || isNaN(lon)) return Promise.resolve(null);
+  return getWeather(lat, lon);
+}
+
 export async function getWeather(lat: number, lon: number): Promise<Weather | null> {
   const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,weather_code&temperature_unit=fahrenheit`;
   const res = await fetch(url);

--- a/backend/test/dashboardService.test.ts
+++ b/backend/test/dashboardService.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockEventFindMany = vi.hoisted(() => vi.fn());
 const mockTaskFindMany = vi.hoisted(() => vi.fn());
 const mockReminderFindMany = vi.hoisted(() => vi.fn());
-const mockGetWeather = vi.hoisted(() => vi.fn());
+const mockGetWeatherFromEnv = vi.hoisted(() => vi.fn());
 
 vi.mock("../src/lib/prisma", () => ({
   prisma: {
@@ -14,7 +14,7 @@ vi.mock("../src/lib/prisma", () => ({
 }));
 
 vi.mock("../src/services/weatherService", () => ({
-  getWeather: mockGetWeather,
+  getWeatherFromEnv: mockGetWeatherFromEnv,
 }));
 
 import { getDashboardSummary } from "../src/services/dashboardService";
@@ -22,9 +22,12 @@ import { getDashboardSummary } from "../src/services/dashboardService";
 const userId = "user-1";
 
 describe("getDashboardSummary", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetWeatherFromEnv.mockResolvedValue(null);
+  });
 
-  it("returns events, tasks, reminders, and weather as null when no coords provided", async () => {
+  it("returns events, tasks, reminders, and weather as null when WEATHER_LOCATION is unset", async () => {
     const fakeEvents = [{ id: "evt-1", title: "Standup" }];
     const fakeTasks = [{ id: "task-1", title: "Fix bug" }];
     const fakeReminders = [{ id: "rem-1", title: "Call dentist" }];
@@ -41,20 +44,19 @@ describe("getDashboardSummary", () => {
       reminders: fakeReminders,
       weather: null,
     });
-    expect(mockGetWeather).not.toHaveBeenCalled();
   });
 
-  it("fetches weather when coords are provided", async () => {
+  it("fetches weather from env var when WEATHER_LOCATION is set", async () => {
     const fakeWeather = { temperature: 72, condition: "clear sky" };
     mockEventFindMany.mockResolvedValue([]);
     mockTaskFindMany.mockResolvedValue([]);
     mockReminderFindMany.mockResolvedValue([]);
-    mockGetWeather.mockResolvedValue(fakeWeather);
+    mockGetWeatherFromEnv.mockResolvedValue(fakeWeather);
 
-    const result = await getDashboardSummary(userId, { lat: 34.05, lon: -118.25 });
+    const result = await getDashboardSummary(userId);
 
     expect(result.weather).toEqual(fakeWeather);
-    expect(mockGetWeather).toHaveBeenCalledWith(34.05, -118.25);
+    expect(mockGetWeatherFromEnv).toHaveBeenCalled();
   });
 
   it("queries events within today's UTC boundaries ordered by startAt", async () => {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -17,14 +17,14 @@ const NAV_ITEMS = [
   { href: "/profile", label: "Profile" },
 ];
 
-export default function Layout({ children }: { children: ReactNode }) {
+export default function Layout({ children, fillHeight = false }: { children: ReactNode; fillHeight?: boolean }) {
   const displayName = localStorage.getItem("displayName");
   const profilePicture = localStorage.getItem("profilePicture");
   const pictureUrl = profilePicture ? `${BASE_URL}${profilePicture}` : null;
   const path = window.location.pathname;
 
   return (
-    <div className="min-h-screen bg-ocean flex">
+    <div className="h-screen bg-ocean flex overflow-hidden">
       <nav className="w-52 shrink-0 glass flex flex-col p-4 m-4 mr-0 rounded-xl">
         <a href="/" className="text-2xl font-bold text-white mb-6 px-2 tracking-tight">Orbit</a>
         <div className="flex flex-col gap-1">
@@ -74,7 +74,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           </button>
         </div>
       </nav>
-      <div className="flex-1 flex flex-col p-8">
+      <div className={`flex-1 flex flex-col p-8 min-h-0 ${fillHeight ? "overflow-hidden" : "overflow-y-auto"}`}>
         {children}
       </div>
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,6 +5,47 @@
     cursor: pointer;
     transition: background-color 150ms ease, color 150ms ease, border-color 150ms ease, opacity 150ms ease, transform 150ms ease, box-shadow 150ms ease;
   }
+
+  select,
+  input[type="date"],
+  input[type="datetime-local"],
+  input[type="time"] {
+    color-scheme: dark;
+  }
+
+  select option {
+    background-color: #0a1e38;
+    color: white;
+  }
+
+  input[type="date"]::-webkit-calendar-picker-indicator,
+  input[type="datetime-local"]::-webkit-calendar-picker-indicator,
+  input[type="time"]::-webkit-calendar-picker-indicator {
+    filter: invert(1);
+    opacity: 0.4;
+    cursor: pointer;
+    border-radius: 4px;
+    padding: 2px;
+    transition: opacity 150ms ease;
+  }
+
+  input[type="date"]::-webkit-calendar-picker-indicator:hover,
+  input[type="datetime-local"]::-webkit-calendar-picker-indicator:hover,
+  input[type="time"]::-webkit-calendar-picker-indicator:hover {
+    opacity: 0.9;
+  }
+
+  input[type="date"],
+  input[type="datetime-local"],
+  input[type="time"] {
+    position: relative;
+  }
+
+  input[type="date"]:focus,
+  input[type="datetime-local"]:focus,
+  input[type="time"]:focus {
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.15);
+  }
 }
 
 @layer utilities {

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -36,8 +36,22 @@ function taskOnDay(task: Task, day: Date) {
   return task.dueDate.slice(0, 10) === dayStr;
 }
 
-function reminderOnDay(reminder: Reminder, day: Date) {
-  return isSameDay(new Date(reminder.scheduledAt), day);
+function reminderOnDay(reminder: Reminder, day: Date): boolean {
+  const scheduled = new Date(reminder.scheduledAt);
+  if (isSameDay(scheduled, day)) return true;
+  if (reminder.repeatFrequency === "NONE" || reminder.status !== "UPCOMING") return false;
+
+  const dayStart = new Date(day); dayStart.setHours(0, 0, 0, 0);
+  const schedStart = new Date(scheduled); schedStart.setHours(0, 0, 0, 0);
+  if (dayStart <= schedStart) return false;
+
+  if (reminder.repeatFrequency === "DAILY") return true;
+
+  const diffDays = Math.round((dayStart.getTime() - schedStart.getTime()) / 86400000);
+  if (reminder.repeatFrequency === "WEEKLY") return diffDays % 7 === 0;
+  if (reminder.repeatFrequency === "MONTHLY") return scheduled.getDate() === day.getDate();
+
+  return false;
 }
 
 function eventOnDay(event: Event, day: Date) {
@@ -108,9 +122,9 @@ function CreateFormModal({
     setError(null);
     if (type === "event") {
       if (new Date(startAt) >= new Date(endAt)) { setError("End must be after start"); return; }
-      await onSaveEvent({ title, description: description || undefined, startAt, endAt });
+      await onSaveEvent({ title, description: description || undefined, startAt: new Date(startAt).toISOString(), endAt: new Date(endAt).toISOString() });
     } else if (type === "reminder") {
-      await onSaveReminder({ title, scheduledAt, repeatFrequency });
+      await onSaveReminder({ title, scheduledAt: new Date(scheduledAt).toISOString(), repeatFrequency });
     } else {
       await onSaveTask({ title, description: description || undefined, dueDate });
     }
@@ -220,7 +234,7 @@ function EventFormModal({
       setError("End must be after start");
       return;
     }
-    await onSave({ title, description: description || undefined, startAt, endAt });
+    await onSave({ title, description: description || undefined, startAt: new Date(startAt).toISOString(), endAt: new Date(endAt).toISOString() });
   }
 
   return (
@@ -275,12 +289,12 @@ function ReminderFormModal({
   onClose: () => void;
 }) {
   const [title, setTitle] = useState(reminder.title);
-  const [scheduledAt, setScheduledAt] = useState(reminder.scheduledAt.slice(0, 16));
+  const [scheduledAt, setScheduledAt] = useState(toLocalInput(new Date(reminder.scheduledAt)));
   const [repeatFrequency, setRepeatFrequency] = useState<RepeatFrequency>(reminder.repeatFrequency);
 
   async function handleSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
     e.preventDefault();
-    await onSave({ title, scheduledAt, repeatFrequency });
+    await onSave({ title, scheduledAt: new Date(scheduledAt).toISOString(), repeatFrequency });
   }
 
   return (
@@ -357,7 +371,7 @@ function TaskEditModal({
           </label>
           <label className="flex flex-col gap-1">
             <span className="text-xs font-medium text-white/50">Due date</span>
-            <input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} className={inputClass} />
+            <input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} className="bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40" />
           </label>
           <div className="flex gap-2 mt-1">
             <Button type="submit" className="flex-1 py-2">Save</Button>
@@ -390,102 +404,106 @@ function TimeGrid({
   const today = new Date(); today.setHours(0, 0, 0, 0);
 
   return (
-    <div className="flex flex-col flex-1 border border-white/15 rounded-xl overflow-hidden">
-      <div className="flex border-b border-white/15 bg-white/5">
-        <div className="w-12 shrink-0" />
-        {days.map((day, i) => {
-          const isToday = isSameDay(day, today);
-          return (
-            <div key={i} className="flex-1 text-center py-2 border-l border-white/10">
-              <p className="text-xs font-semibold text-white/50 uppercase tracking-wide">{DAY_NAMES[day.getDay()]}</p>
-              <span className={`inline-flex items-center justify-center w-7 h-7 rounded-full text-sm font-medium mt-0.5 ${isToday ? "bg-white/20 text-white" : "text-white/70"}`}>
-                {day.getDate()}
-              </span>
-            </div>
-          );
-        })}
-      </div>
+    <div className="flex flex-col flex-1 min-h-0 border border-white/15 rounded-xl overflow-hidden">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto min-h-0">
+        <div className="sticky top-0 z-20 bg-[#0a1e38]">
+          <div className="flex border-b border-white/15 bg-white/5">
+            <div className="w-12 shrink-0" />
+            {days.map((day, i) => {
+              const isToday = isSameDay(day, today);
+              return (
+                <div key={i} className="flex-1 text-center py-2 border-l border-white/10">
+                  <p className="text-xs font-semibold text-white/50 uppercase tracking-wide">{DAY_NAMES[day.getDay()]}</p>
+                  <span className={`inline-flex items-center justify-center w-7 h-7 rounded-full text-sm font-medium mt-0.5 ${isToday ? "bg-white/20 text-white" : "text-white/70"}`}>
+                    {day.getDate()}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
 
-      <div className="flex border-b border-white/15 bg-white/5">
-        <div className="w-12 shrink-0 flex items-center justify-end pr-2 py-1">
-          <span className="text-xs text-white/30">all-day</span>
-        </div>
-        {days.map((day, i) => {
-          const dayTasks = tasks.filter((t) => taskOnDay(t, day));
-          return (
-            <div key={i} className="flex-1 border-l border-white/10 py-0.5 px-1 min-h-5">
-              {dayTasks.map((task) => (
-                <div key={task.id} data-event onClick={() => onTaskClick(task)} className="text-xs bg-amber-500/80 text-white rounded px-1 py-0.5 truncate mb-0.5 cursor-pointer hover:bg-amber-400/80 transition-colors duration-150">{task.title}</div>
-              ))}
+          <div className="flex border-b border-white/15 bg-white/5">
+            <div className="w-12 shrink-0 flex items-center justify-end pr-2 py-1">
+              <span className="text-xs text-white/30">all-day</span>
             </div>
-          );
-        })}
-      </div>
-
-      <div ref={scrollRef} className="flex overflow-y-auto" style={{ maxHeight: 600 }}>
-        <div className="w-12 shrink-0 relative" style={{ height: 24 * HOUR_HEIGHT }}>
-          {Array.from({ length: 24 }, (_, h) => (
-            <div key={h} className="absolute right-2 text-xs text-white/30" style={{ top: h * HOUR_HEIGHT - 8 }}>
-              {h === 0 ? "" : `${h}:00`}
-            </div>
-          ))}
+            {days.map((day, i) => {
+              const dayTasks = tasks.filter((t) => taskOnDay(t, day));
+              return (
+                <div key={i} className="flex-1 border-l border-white/10 py-0.5 px-1 min-h-5">
+                  {dayTasks.map((task) => (
+                    <div key={task.id} data-event onClick={() => onTaskClick(task)} className="text-xs bg-amber-500/80 text-white rounded px-1 py-0.5 truncate mb-0.5 cursor-pointer hover:bg-amber-400/80 transition-colors duration-150">{task.title}</div>
+                  ))}
+                </div>
+              );
+            })}
+          </div>
         </div>
 
-        {days.map((day, di) => {
-          const dayEvents = events.filter((e) => eventOnDay(e, day));
-          const layout = layoutDayEvents(dayEvents);
-          const dayReminders = reminders.filter((r) => reminderOnDay(r, day));
-          return (
-            <div
-              key={di}
-              className="flex-1 relative border-l border-white/10"
-              style={{ height: 24 * HOUR_HEIGHT }}
-              onClick={(e) => {
-                if ((e.target as HTMLElement).closest("[data-event]")) return;
-                const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
-                const y = e.clientY - rect.top;
-                const hour = Math.floor(y / HOUR_HEIGHT);
-                const minutes = Math.round(((y % HOUR_HEIGHT) / HOUR_HEIGHT) * 60 / 15) * 15;
-                const d = new Date(day); d.setHours(hour, minutes, 0, 0);
-                onSlotClick(d);
-              }}
-            >
-              {Array.from({ length: 24 }, (_, h) => (
-                <div key={h} className="absolute w-full border-t border-white/5 pointer-events-none" style={{ top: h * HOUR_HEIGHT }} />
-              ))}
-              {dayReminders.map((reminder) => {
-                const scheduled = new Date(reminder.scheduledAt);
-                const top = (scheduled.getHours() + scheduled.getMinutes() / 60) * HOUR_HEIGHT;
-                return (
-                  <div key={reminder.id} data-event className="absolute z-10 rounded px-1.5 py-0.5 bg-violet-500/80 text-white text-xs overflow-hidden cursor-pointer hover:bg-violet-400/80 transition-colors duration-150" style={{ top, height: 22, left: 0, right: 0 }} onClick={() => onReminderClick(reminder)}>
-                    <p className="font-medium truncate leading-tight">{reminder.title}</p>
-                  </div>
-                );
-              })}
-              {dayEvents.map((event) => {
-                const start = new Date(event.startAt);
-                const end = new Date(event.endAt);
-                const top = (start.getHours() + start.getMinutes() / 60) * HOUR_HEIGHT;
-                const height = Math.max(20, ((end.getTime() - start.getTime()) / 3600000) * HOUR_HEIGHT);
-                const pos = layout.get(event.id) ?? { col: 0, cols: 1 };
-                const width = 100 / pos.cols;
-                const left = pos.col * width;
-                return (
-                  <div
-                    key={event.id}
-                    data-event
-                    onClick={() => onEventClick(event)}
-                    className="absolute z-10 rounded px-1.5 py-0.5 bg-cyan-500/80 text-white text-xs overflow-hidden cursor-pointer hover:bg-cyan-400/80 transition-colors duration-150"
-                    style={{ top, height, left: `${left}%`, width: `${width}%` }}
-                  >
-                    <p className="font-medium truncate leading-tight">{event.title}</p>
-                    <p className="text-white/50 truncate leading-tight">{start.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</p>
-                  </div>
-                );
-              })}
-            </div>
-          );
-        })}
+        <div className="flex">
+          <div className="w-12 shrink-0 relative" style={{ height: 24 * HOUR_HEIGHT }}>
+            {Array.from({ length: 24 }, (_, h) => (
+              <div key={h} className="absolute right-2 text-xs text-white/30" style={{ top: h * HOUR_HEIGHT, transform: "translateY(-50%)" }}>
+                {h === 0 ? "" : `${h}:00`}
+              </div>
+            ))}
+          </div>
+
+          {days.map((day, di) => {
+            const dayEvents = events.filter((e) => eventOnDay(e, day));
+            const layout = layoutDayEvents(dayEvents);
+            const dayReminders = reminders.filter((r) => reminderOnDay(r, day));
+            return (
+              <div
+                key={di}
+                className="flex-1 relative border-l border-white/10"
+                style={{ height: 24 * HOUR_HEIGHT }}
+                onClick={(e) => {
+                  if ((e.target as HTMLElement).closest("[data-event]")) return;
+                  const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
+                  const y = e.clientY - rect.top;
+                  const hour = Math.floor(y / HOUR_HEIGHT);
+                  const minutes = Math.round(((y % HOUR_HEIGHT) / HOUR_HEIGHT) * 60 / 15) * 15;
+                  const d = new Date(day); d.setHours(hour, minutes, 0, 0);
+                  onSlotClick(d);
+                }}
+              >
+                {Array.from({ length: 24 }, (_, h) => (
+                  <div key={h} className="absolute w-full border-t border-white/5 pointer-events-none" style={{ top: h * HOUR_HEIGHT }} />
+                ))}
+                {dayReminders.map((reminder) => {
+                  const scheduled = new Date(reminder.scheduledAt);
+                  const top = (scheduled.getHours() + scheduled.getMinutes() / 60) * HOUR_HEIGHT;
+                  return (
+                    <div key={reminder.id} data-event className="absolute z-10 rounded px-1.5 py-0.5 bg-violet-500/80 text-white text-xs overflow-hidden cursor-pointer hover:bg-violet-400/80 transition-colors duration-150" style={{ top, height: 22, left: 0, right: 0 }} onClick={() => onReminderClick(reminder)}>
+                      <p className="font-medium truncate leading-tight">{reminder.title}</p>
+                    </div>
+                  );
+                })}
+                {dayEvents.map((event) => {
+                  const start = new Date(event.startAt);
+                  const end = new Date(event.endAt);
+                  const top = (start.getHours() + start.getMinutes() / 60) * HOUR_HEIGHT;
+                  const height = Math.max(20, ((end.getTime() - start.getTime()) / 3600000) * HOUR_HEIGHT);
+                  const pos = layout.get(event.id) ?? { col: 0, cols: 1 };
+                  const width = 100 / pos.cols;
+                  const left = pos.col * width;
+                  return (
+                    <div
+                      key={event.id}
+                      data-event
+                      onClick={() => onEventClick(event)}
+                      className="absolute z-10 rounded px-1.5 py-0.5 bg-cyan-500/80 text-white text-xs overflow-hidden cursor-pointer hover:bg-cyan-400/80 transition-colors duration-150"
+                      style={{ top, height, left: `${left}%`, width: `${width}%` }}
+                    >
+                      <p className="font-medium truncate leading-tight">{event.title}</p>
+                      <p className="text-white/50 truncate leading-tight">{start.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</p>
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );
@@ -507,7 +525,7 @@ function MonthView({
   while (cells.length < 42) { cells.push(new Date(d)); d.setDate(d.getDate() + 1); }
 
   return (
-    <div className="flex-1">
+    <div className="flex-1 min-h-0 overflow-y-auto">
       <div className="grid grid-cols-7 border-l border-t border-white/15 rounded-xl overflow-hidden">
         {DAY_NAMES.map((name) => (
           <div key={name} className="border-r border-b border-white/15 py-2 text-center text-xs font-semibold text-white/50 uppercase tracking-wide bg-white/5">
@@ -682,7 +700,8 @@ export default function CalendarPage() {
   }
 
   return (
-    <Layout>
+    <Layout fillHeight>
+      <div className="flex flex-col h-full min-h-0">
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-2xl font-bold text-white">Calendar</h1>
         <div className="flex border border-white/20 rounded-lg overflow-hidden text-sm">
@@ -722,10 +741,12 @@ export default function CalendarPage() {
         <TimeGrid days={getWeekDays()} events={events} tasks={tasks} reminders={reminders} onSlotClick={openCreate} onEventClick={(event) => setModal({ mode: "edit", event })} onReminderClick={setReminderModal} onTaskClick={setTaskModal} />
       )}
       {view === "day" && (
-        <div className="max-w-xl">
+        <div className="max-w-xl flex-1 min-h-0 flex flex-col">
           <TimeGrid days={[cursor]} events={events} tasks={tasks} reminders={reminders} onSlotClick={openCreate} onEventClick={(event) => setModal({ mode: "edit", event })} onReminderClick={setReminderModal} onTaskClick={setTaskModal} />
         </div>
       )}
+
+      </div>
 
       {modal && (
         <EventFormModal

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import type { Task, Reminder, Event } from "../types";
 import { apiFetch } from "../lib/api";
 import Layout from "../components/Layout";
@@ -43,16 +43,6 @@ function formatTime(iso: string) {
   return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-function getLocation(): Promise<{ lat: number; lon: number } | null> {
-  return new Promise((resolve) => {
-    if (!navigator.geolocation) { resolve(null); return; }
-    navigator.geolocation.getCurrentPosition(
-      (pos) => resolve({ lat: pos.coords.latitude, lon: pos.coords.longitude }),
-      () => resolve(null),
-      { timeout: 5000 },
-    );
-  });
-}
 
 function ExpandableTask({
   task,
@@ -187,8 +177,6 @@ export default function DashboardPage() {
     }
     return false;
   });
-  const coordsRef = useRef<{ lat: number; lon: number } | null>(null);
-
   useEffect(() => {
     if (!showWelcome) return;
     const timer = setTimeout(() => setShowWelcome(false), 3000);
@@ -197,19 +185,20 @@ export default function DashboardPage() {
 
   useEffect(() => {
     async function load() {
-      const coords = await getLocation();
-      coordsRef.current = coords;
-      const params = coords ? `?lat=${coords.lat}&lon=${coords.lon}` : "";
-      const [dashRes, taskRes, remRes] = await Promise.all([
-        apiFetch(`/api/v1/dashboard${params}`),
+      const [dashRes, eventsRes, taskRes, remRes] = await Promise.all([
+        apiFetch("/api/v1/dashboard"),
+        apiFetch("/api/v1/events"),
         apiFetch("/api/v1/tasks"),
         apiFetch("/api/v1/reminders"),
       ]);
       if (dashRes.ok) {
-        const d = (await dashRes.json()) as { data: { events: Event[]; weather: Weather | null; streak: Streak } };
-        setEvents(d.data.events);
+        const d = (await dashRes.json()) as { data: { weather: Weather | null; streak: Streak } };
         setWeather(d.data.weather);
         setStreak(d.data.streak);
+      }
+      if (eventsRes.ok) {
+        const d = (await eventsRes.json()) as { data: Event[] };
+        setEvents(d.data);
       }
       if (taskRes.ok) {
         const d = (await taskRes.json()) as { data: Task[] };
@@ -278,11 +267,10 @@ export default function DashboardPage() {
 
   async function handleGetBriefing() {
     setBriefing({ status: "loading" });
-    const payload: Record<string, unknown> = {
+    const payload = {
       localTime: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: true }),
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     };
-    if (coordsRef.current) { payload.lat = coordsRef.current.lat; payload.lon = coordsRef.current.lon; }
     const res = await apiFetch("/api/v1/dashboard/briefing", { method: "POST", body: JSON.stringify(payload) });
     if (!res.ok) {
       const data = (await res.json()) as { error?: string };

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -332,34 +332,34 @@ export default function ProfilePage() {
           </form>
         </Card>
 
-        <Card className="w-48">
-          <p className="text-[10px] font-semibold text-white/40 uppercase tracking-wide mb-2">Streak</p>
-          <div className="flex gap-4 mb-3">
+        <Card className="w-56">
+          <p className="text-xs font-semibold text-white/40 uppercase tracking-wide mb-4">Streak</p>
+          <div className="flex gap-6 mb-5">
             <div>
-              <p className="text-lg font-bold text-white">{profile.currentStreak}</p>
-              <p className="text-[10px] text-white/40">Current</p>
+              <p className="text-4xl font-bold text-white leading-none">{profile.currentStreak}</p>
+              <p className="text-xs text-white/40 mt-1">Current</p>
             </div>
             <div>
-              <p className="text-lg font-bold text-white">{profile.longestStreak}</p>
-              <p className="text-[10px] text-white/40">Longest</p>
+              <p className="text-4xl font-bold text-white leading-none">{profile.longestStreak}</p>
+              <p className="text-xs text-white/40 mt-1">Longest</p>
             </div>
           </div>
-          <div className="border-t border-white/10 pt-2">
-            <div className="flex flex-col gap-1.5">
+          <div className="border-t border-white/10 pt-3">
+            <div className="flex flex-col gap-2.5">
               {[
                 { icon: "🐚", name: "Shell", milestone: 3 },
                 { icon: "🦪", name: "Pearl", milestone: 7 },
                 { icon: "🌊", name: "Wave", milestone: 14 },
                 { icon: "⚓", name: "Anchor", milestone: 30 },
               ].map((b) => (
-                <div key={b.name} className="flex items-center gap-1.5">
-                  <span className={`text-xs ${profile.longestStreak >= b.milestone ? "" : "opacity-30"}`}>{b.icon}</span>
-                  <span className={`text-[10px] ${profile.longestStreak >= b.milestone ? "text-white/60" : "text-white/25"}`}>{b.name}</span>
-                  {profile.longestStreak < b.milestone && <span className="text-[10px] text-white/20 ml-auto">{b.milestone}d</span>}
+                <div key={b.name} className="flex items-center gap-2">
+                  <span className={`text-base ${profile.longestStreak >= b.milestone ? "" : "opacity-30"}`}>{b.icon}</span>
+                  <span className={`text-sm ${profile.longestStreak >= b.milestone ? "text-white/70" : "text-white/30"}`}>{b.name}</span>
+                  {profile.longestStreak < b.milestone && <span className="text-xs text-white/30 ml-auto">{b.milestone}d</span>}
                 </div>
               ))}
             </div>
-            <p className="text-[9px] text-white/20 mt-2">Keep your streak alive to collect these.</p>
+            <p className="text-xs text-white/25 mt-3">Keep your streak alive to collect these.</p>
           </div>
         </Card>
         </div>

--- a/frontend/src/pages/RemindersPage.tsx
+++ b/frontend/src/pages/RemindersPage.tsx
@@ -5,6 +5,11 @@ import Layout from "../components/Layout";
 import Card from "../components/Card";
 import Button from "../components/Button";
 
+function toLocalInput(d: Date) {
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 const REPEAT_LABELS: Record<RepeatFrequency, string> = {
   NONE: "One-time",
   DAILY: "Daily",
@@ -25,7 +30,7 @@ function ReminderCard({
 }) {
   const [open, setOpen] = useState(false);
   const [editTitle, setEditTitle] = useState(reminder.title);
-  const [editScheduledAt, setEditScheduledAt] = useState(reminder.scheduledAt.slice(0, 16));
+  const [editScheduledAt, setEditScheduledAt] = useState(toLocalInput(new Date(reminder.scheduledAt)));
   const [editRepeat, setEditRepeat] = useState<RepeatFrequency>(reminder.repeatFrequency);
 
   async function handleComplete() {
@@ -41,14 +46,14 @@ function ReminderCard({
   async function handleSave() {
     const res = await apiFetch(`/api/v1/reminders/${reminder.id}`, {
       method: "PATCH",
-      body: JSON.stringify({ title: editTitle, scheduledAt: editScheduledAt, repeatFrequency: editRepeat }),
+      body: JSON.stringify({ title: editTitle, scheduledAt: new Date(editScheduledAt).toISOString(), repeatFrequency: editRepeat }),
     });
     if (res.ok) { setOpen(false); await onRefresh(); }
   }
 
   function handleOpen() {
     setEditTitle(reminder.title);
-    setEditScheduledAt(reminder.scheduledAt.slice(0, 16));
+    setEditScheduledAt(toLocalInput(new Date(reminder.scheduledAt)));
     setEditRepeat(reminder.repeatFrequency);
     setOpen(true);
   }
@@ -120,7 +125,7 @@ function CreateCard({ onRefresh }: { onRefresh: () => Promise<void> }) {
     if (!title || !scheduledAt) { setError("Title and time are required"); return; }
     const res = await apiFetch("/api/v1/reminders", {
       method: "POST",
-      body: JSON.stringify({ title, scheduledAt, repeatFrequency }),
+      body: JSON.stringify({ title, scheduledAt: new Date(scheduledAt).toISOString(), repeatFrequency }),
     });
     if (!res.ok) {
       const data = (await res.json()) as { error?: string };


### PR DESCRIPTION
## Summary
- Fix datetime timezone drift across Calendar and Reminders (use `toLocalInput()` on init, `.toISOString()` on submit)
- Fix dashboard events not appearing by switching to client-side local-time filtering
- Fix week/day calendar column misalignment caused by scrollbar width discrepancy
- Fix hour label alignment in week/day time grid
- Make calendar fill full viewport height (remove hardcoded 600px max)
- Make the app fit the screen on any monitor size (`h-screen` layout)
- Enlarge streak card on Profile page for readability
- Switch weather from browser geolocation to `WEATHER_LOCATION` env var
- Fix select/dropdown and date picker visibility on Windows (dark mode CSS)

## Test plan
- [ ] Create and edit an event/reminder on Calendar — times should not drift after save
- [ ] Verify today's events appear on the Dashboard
- [ ] Open week view on Calendar — column borders should align across header, all-day, and time grid
- [ ] On a large monitor, Calendar should fill the full screen height
- [ ] On Profile page, streak numbers should be large and clearly readable
- [ ] Dropdowns and date pickers should be styled correctly on Windows

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)