### PR TITLE
fix(frontend): replace date/time pickers with lightweight custom pick…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,12 @@
 services:
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: orbit
-    ports:
-      - "5432:5432"
-    volumes:
-      - db_data:/var/lib/postgresql/data
-
   backend:
     build: ./backend
     ports:
       - "3000:3000"
-    environment:
-      DATABASE_URL: postgresql://postgres:password@db:5432/orbit
-      JWT_SECRET: ${JWT_SECRET}
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+    env_file:
+      - .env
     volumes:
       - ./backend/uploads:/app/uploads
-    depends_on:
-      - db
 
   frontend:
     build: ./frontend
@@ -29,6 +14,3 @@ services:
       - "5173:5173"
     depends_on:
       - backend
-
-volumes:
-  db_data:

--- a/frontend/src/components/DatePicker.tsx
+++ b/frontend/src/components/DatePicker.tsx
@@ -1,0 +1,107 @@
+import { useState, useRef, useEffect } from "react";
+
+const MONTH_NAMES = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+const DAY_NAMES = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+
+export default function DatePicker({
+  value,
+  onChange,
+  className = "",
+}: {
+  value: string;
+  onChange: (val: string) => void;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const parsed = value ? new Date(value + "T00:00:00") : new Date();
+  const [viewYear, setViewYear] = useState(parsed.getFullYear());
+  const [viewMonth, setViewMonth] = useState(parsed.getMonth());
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  const firstDay = new Date(viewYear, viewMonth, 1).getDay();
+  const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+  const cells: (number | null)[] = Array.from({ length: firstDay }, () => null);
+  for (let d = 1; d <= daysInMonth; d++) cells.push(d);
+
+  function select(day: number) {
+    onChange(`${viewYear}-${pad(viewMonth + 1)}-${pad(day)}`);
+    setOpen(false);
+  }
+
+  function prev() {
+    if (viewMonth === 0) { setViewMonth(11); setViewYear(viewYear - 1); }
+    else setViewMonth(viewMonth - 1);
+  }
+
+  function next() {
+    if (viewMonth === 11) { setViewMonth(0); setViewYear(viewYear + 1); }
+    else setViewMonth(viewMonth + 1);
+  }
+
+  const display = value
+    ? `${MONTH_NAMES[parsed.getMonth()]} ${parsed.getDate()}, ${parsed.getFullYear()}`
+    : "Select date";
+
+  const selectedStr = value;
+
+  return (
+    <div ref={ref} className={`relative ${className}`}>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-full text-left bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40"
+      >
+        {display}
+      </button>
+      {open && (
+        <div className="absolute z-30 mt-1 bg-[#0a1e38]/95 border border-white/20 rounded-xl shadow-xl p-3 w-64">
+          <div className="flex items-center justify-between mb-2">
+            <button type="button" onClick={prev} className="text-white/50 hover:text-white px-1">‹</button>
+            <span className="text-xs font-medium text-white">{MONTH_NAMES[viewMonth]} {viewYear}</span>
+            <button type="button" onClick={next} className="text-white/50 hover:text-white px-1">›</button>
+          </div>
+          <div className="grid grid-cols-7 gap-0.5 text-center">
+            {DAY_NAMES.map((d) => (
+              <span key={d} className="text-[10px] text-white/30 py-0.5">{d}</span>
+            ))}
+            {cells.map((day, i) => {
+              if (day === null) return <span key={`e-${i}`} />;
+              const dateStr = `${viewYear}-${pad(viewMonth + 1)}-${pad(day)}`;
+              const isSelected = dateStr === selectedStr;
+              const isToday = dateStr === `${new Date().getFullYear()}-${pad(new Date().getMonth() + 1)}-${pad(new Date().getDate())}`;
+              return (
+                <button
+                  key={day}
+                  type="button"
+                  onClick={() => select(day)}
+                  className={`text-xs py-1 rounded transition-colors duration-100 ${
+                    isSelected
+                      ? "bg-white/25 text-white font-medium"
+                      : isToday
+                      ? "text-emerald-400 hover:bg-white/10"
+                      : "text-white/70 hover:bg-white/10"
+                  }`}
+                >
+                  {day}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/DateTimePicker.tsx
+++ b/frontend/src/components/DateTimePicker.tsx
@@ -1,0 +1,117 @@
+import { useState, useRef, useEffect } from "react";
+import DatePicker from "./DatePicker";
+
+function pad(n: number) { return n.toString().padStart(2, "0"); }
+
+function parseDateTime(val: string): { date: string; hour: number; minute: number } {
+  if (!val) {
+    const now = new Date();
+    return {
+      date: `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`,
+      hour: now.getHours(),
+      minute: 0,
+    };
+  }
+  const [datePart, timePart] = val.split("T");
+  const [h, m] = (timePart ?? "12:00").split(":").map(Number);
+  return { date: datePart, hour: h, minute: m };
+}
+
+function formatHour(h: number) {
+  if (h === 0) return "12 AM";
+  if (h < 12) return `${h} AM`;
+  if (h === 12) return "12 PM";
+  return `${h - 12} PM`;
+}
+
+function TimeSelect({
+  value,
+  options,
+  format,
+  onChange,
+}: {
+  value: number;
+  options: number[];
+  format: (v: number) => string;
+  onChange: (v: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, []);
+
+  useEffect(() => {
+    if (open && listRef.current) {
+      const idx = options.indexOf(value);
+      if (idx > 0) listRef.current.scrollTop = idx * 28 - 56;
+    }
+  }, [open, options, value]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40 whitespace-nowrap"
+      >
+        {format(value)}
+      </button>
+      {open && (
+        <div ref={listRef} className="absolute z-30 mt-1 bg-[#0a1e38]/95 border border-white/20 rounded-xl shadow-xl py-1 w-20 max-h-48 overflow-y-auto">
+          {options.map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => { onChange(opt); setOpen(false); }}
+              className={`block w-full text-left text-xs px-3 py-1 transition-colors duration-100 ${
+                value === opt ? "bg-white/20 text-white font-medium" : "text-white/70 hover:bg-white/10"
+              }`}
+            >
+              {format(opt)}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+const MINUTES = Array.from({ length: 12 }, (_, i) => i * 5);
+
+export default function DateTimePicker({
+  value,
+  onChange,
+  className = "",
+}: {
+  value: string;
+  onChange: (val: string) => void;
+  className?: string;
+}) {
+  const parsed = parseDateTime(value);
+  const [date, setDate] = useState(parsed.date);
+  const [hour, setHour] = useState(parsed.hour);
+  const [minute, setMinute] = useState(parsed.minute);
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    if (!initialized.current) { initialized.current = true; return; }
+    onChange(`${date}T${pad(hour)}:${pad(minute)}`);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [date, hour, minute]);
+
+  return (
+    <div className={`flex gap-2 items-start ${className}`}>
+      <DatePicker value={date} onChange={setDate} className="flex-1" />
+      <TimeSelect value={hour} options={HOURS} format={formatHour} onChange={setHour} />
+      <TimeSelect value={minute} options={MINUTES} format={pad} onChange={setMinute} />
+    </div>
+  );
+}

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef } from "react";
 import Layout from "../components/Layout";
 import Button from "../components/Button";
+import DatePicker from "../components/DatePicker";
+import DateTimePicker from "../components/DateTimePicker";
 import { apiFetch } from "../lib/api";
 import type { Event, Task, Reminder, RepeatFrequency } from "../types";
 
@@ -159,22 +161,22 @@ function CreateFormModal({
           )}
           {type === "event" && (
             <>
-              <label className="flex flex-col gap-1">
+              <div className="flex flex-col gap-1">
                 <span className="text-xs font-medium text-white/50">Start</span>
-                <input type="datetime-local" value={startAt} onChange={(e) => setStartAt(e.target.value)} required className={inputClass} />
-              </label>
-              <label className="flex flex-col gap-1">
+                <DateTimePicker value={startAt} onChange={setStartAt} />
+              </div>
+              <div className="flex flex-col gap-1">
                 <span className="text-xs font-medium text-white/50">End</span>
-                <input type="datetime-local" value={endAt} onChange={(e) => setEndAt(e.target.value)} required className={inputClass} />
-              </label>
+                <DateTimePicker value={endAt} onChange={setEndAt} />
+              </div>
             </>
           )}
           {type === "reminder" && (
             <>
-              <label className="flex flex-col gap-1">
+              <div className="flex flex-col gap-1">
                 <span className="text-xs font-medium text-white/50">Scheduled at</span>
-                <input type="datetime-local" value={scheduledAt} onChange={(e) => setScheduledAt(e.target.value)} required className={inputClass} />
-              </label>
+                <DateTimePicker value={scheduledAt} onChange={setScheduledAt} />
+              </div>
               <label className="flex flex-col gap-1">
                 <span className="text-xs font-medium text-white/50">Repeat</span>
                 <select value={repeatFrequency} onChange={(e) => setRepeatFrequency(e.target.value as RepeatFrequency)} className={inputClass}>
@@ -187,10 +189,10 @@ function CreateFormModal({
             </>
           )}
           {type === "task" && (
-            <label className="flex flex-col gap-1">
+            <div className="flex flex-col gap-1">
               <span className="text-xs font-medium text-white/50">Due date</span>
-              <input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} required className={inputClass} />
-            </label>
+              <DatePicker value={dueDate} onChange={setDueDate} />
+            </div>
           )}
           <div className="flex gap-2 mt-1">
             <Button type="submit" className="flex-1 py-2">Create</Button>
@@ -254,14 +256,14 @@ function EventFormModal({
             <span className="text-xs font-medium text-white/50">Description</span>
             <input type="text" value={description} onChange={(e) => setDescription(e.target.value)} className="bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40" />
           </label>
-          <label className="flex flex-col gap-1">
+          <div className="flex flex-col gap-1">
             <span className="text-xs font-medium text-white/50">Start</span>
-            <input type="datetime-local" value={startAt} onChange={(e) => setStartAt(e.target.value)} required className="bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40" />
-          </label>
-          <label className="flex flex-col gap-1">
+            <DateTimePicker value={startAt} onChange={setStartAt} />
+          </div>
+          <div className="flex flex-col gap-1">
             <span className="text-xs font-medium text-white/50">End</span>
-            <input type="datetime-local" value={endAt} onChange={(e) => setEndAt(e.target.value)} required className="bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40" />
-          </label>
+            <DateTimePicker value={endAt} onChange={setEndAt} />
+          </div>
           <div className="flex gap-2 mt-1">
             <Button type="submit" className="flex-1 py-2">{mode === "create" ? "Create" : "Save"}</Button>
             <Button variant="secondary" type="button" onClick={onClose} className="flex-1 py-2">Cancel</Button>
@@ -307,10 +309,10 @@ function ReminderFormModal({
             <span className="text-xs font-medium text-white/50">Title</span>
             <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} required autoFocus className="bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40" />
           </label>
-          <label className="flex flex-col gap-1">
+          <div className="flex flex-col gap-1">
             <span className="text-xs font-medium text-white/50">Scheduled at</span>
-            <input type="datetime-local" value={scheduledAt} onChange={(e) => setScheduledAt(e.target.value)} required className="bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40" />
-          </label>
+            <DateTimePicker value={scheduledAt} onChange={setScheduledAt} />
+          </div>
           <label className="flex flex-col gap-1">
             <span className="text-xs font-medium text-white/50">Repeat</span>
             <select value={repeatFrequency} onChange={(e) => setRepeatFrequency(e.target.value as RepeatFrequency)} className="bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40">
@@ -369,10 +371,10 @@ function TaskEditModal({
             <span className="text-xs font-medium text-white/50">Description <span className="text-white/30">(optional)</span></span>
             <input type="text" value={description} onChange={(e) => setDescription(e.target.value)} className={inputClass} />
           </label>
-          <label className="flex flex-col gap-1">
+          <div className="flex flex-col gap-1">
             <span className="text-xs font-medium text-white/50">Due date</span>
-            <input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} className="bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40" />
-          </label>
+            <DatePicker value={dueDate} onChange={setDueDate} />
+          </div>
           <div className="flex gap-2 mt-1">
             <Button type="submit" className="flex-1 py-2">Save</Button>
             <Button variant="secondary" type="button" onClick={onClose} className="flex-1 py-2">Cancel</Button>

--- a/frontend/src/pages/RemindersPage.tsx
+++ b/frontend/src/pages/RemindersPage.tsx
@@ -4,6 +4,7 @@ import { apiFetch } from "../lib/api";
 import Layout from "../components/Layout";
 import Card from "../components/Card";
 import Button from "../components/Button";
+import DateTimePicker from "../components/DateTimePicker";
 
 function toLocalInput(d: Date) {
   const pad = (n: number) => n.toString().padStart(2, "0");
@@ -89,10 +90,10 @@ function ReminderCard({
             <span className="text-xs text-white/50">Title</span>
             <input type="text" value={editTitle} onChange={(e) => setEditTitle(e.target.value)} className={inputClass} />
           </label>
-          <label className="block mb-2">
+          <div className="block mb-2">
             <span className="text-xs text-white/50">Scheduled at</span>
-            <input type="datetime-local" value={editScheduledAt} onChange={(e) => setEditScheduledAt(e.target.value)} className={inputClass} />
-          </label>
+            <DateTimePicker value={editScheduledAt} onChange={setEditScheduledAt} className="mt-1" />
+          </div>
           <label className="block mb-3">
             <span className="text-xs text-white/50">Repeat</span>
             <select value={editRepeat} onChange={(e) => setEditRepeat(e.target.value as RepeatFrequency)} className={inputClass}>
@@ -160,10 +161,10 @@ function CreateCard({ onRefresh }: { onRefresh: () => Promise<void> }) {
         <span className="text-xs text-white/50">Title</span>
         <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} autoFocus className={inputClass} />
       </label>
-      <label className="block mb-2">
+      <div className="block mb-2">
         <span className="text-xs text-white/50">Scheduled at</span>
-        <input type="datetime-local" value={scheduledAt} onChange={(e) => setScheduledAt(e.target.value)} className={inputClass} />
-      </label>
+        <DateTimePicker value={scheduledAt} onChange={setScheduledAt} className="mt-1" />
+      </div>
       <label className="block mb-3">
         <span className="text-xs text-white/50">Repeat</span>
         <select value={repeatFrequency} onChange={(e) => setRepeatFrequency(e.target.value as RepeatFrequency)} className={inputClass}>

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -3,6 +3,7 @@ import type { FormEvent } from "react";
 import type { Task } from "../types";
 import { apiFetch } from "../lib/api";
 import Layout from "../components/Layout";
+import DatePicker from "../components/DatePicker";
 import Card from "../components/Card";
 import Button from "../components/Button";
 
@@ -92,17 +93,12 @@ function TaskCard({
               className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white resize-none focus:outline-none focus:border-white/40"
             />
           </label>
-          <label className="block mb-3">
+          <div className="block mb-3">
             <span className="text-xs font-medium text-white/50">
               Due date <span className="text-white/30">(optional)</span>
             </span>
-            <input
-              type="date"
-              value={editDueDate}
-              onChange={(e) => setEditDueDate(e.target.value)}
-              className="mt-1 block w-full bg-white/10 border border-white/20 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-white/40"
-            />
-          </label>
+            <DatePicker value={editDueDate} onChange={setEditDueDate} className="mt-1" />
+          </div>
           <div className="flex gap-2">
             <Button type="submit" className="flex-1 py-1.5">Save</Button>
             <Button variant="secondary" type="button" onClick={() => setEditing(false)} className="flex-1 py-1.5">Cancel</Button>
@@ -256,10 +252,10 @@ export default function TasksPage() {
                 <span className="text-xs text-white/50">Description <span className="text-white/30">(optional)</span></span>
                 <input type="text" value={description} onChange={(e) => setDescription(e.target.value)} className={inputClass} />
               </label>
-              <label className="block mb-3">
+              <div className="block mb-3">
                 <span className="text-xs text-white/50">Due date <span className="text-white/30">(optional)</span></span>
-                <input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} className={inputClass} />
-              </label>
+                <DatePicker value={dueDate} onChange={setDueDate} className="mt-1" />
+              </div>
               <div className="flex gap-2">
                 <Button type="submit" className="text-xs px-3 py-1.5">Save</Button>
                 <Button variant="secondary" type="button" onClick={() => setShowForm(false)} className="text-xs px-3 py-1.5">Cancel</Button>


### PR DESCRIPTION
…ers (#129)

Replace all native date and datetime-local inputs with custom lightweight pickers that match the M7 underwater theme.

New components:
- DatePicker: calendar dropdown with month grid, prev/next navigation, today highlight (emerald), selected date highlight (white). Dark ocean panel (bg-[#0a1e38]/95) with white/20 border. Click-outside to close
- DateTimePicker: combines DatePicker with custom TimeSelect dropdowns for hour (12-hour format with AM/PM) and minute (5-min increments). TimeSelect uses the same dark panel style as DatePicker, scrollable list that auto-scrolls to current value on open

Replaced across all pages:
- CalendarPage: 6 datetime-local inputs and 2 date inputs in CreateFormModal, EventFormModal, ReminderFormModal, TaskEditModal
- TasksPage: 2 date inputs in edit and create forms
- RemindersPage: 2 datetime-local inputs in edit card and create card

Event edit time fix:
- Minute dropdown offers 5-minute increments (0-55) instead of 15-min, so events with non-quarter-hour times display and save correctly

Docker:
- Simplified docker-compose.yml to read all config from .env file (DATABASE_URL, JWT_SECRET, ANTHROPIC_API_KEY, WEATHER_LOCATION). Removed hardcoded env vars and the Docker db service since the dev database is hosted externally