### PR TITLE
feat(backend/frontend): revert weather integration to browser geolocation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,17 @@
-# PostgreSQL connection string used by Prisma to connect to the database
-DATABASE_URL="postgresql://postgres:password@localhost:5432/orbit"
-
-# Secret key used to sign and verify JWT authentication tokens
-JWT_SECRET="youre secret here"
-
-# Application environment — controls logging, error detail, etc.
-NODE_ENV=development
-
-# Port the backend HTTP server listens on
+# Port the backend Express server listens on
 PORT=3000
 
-# Base URL of the backend API, used by the Vite frontend to make requests
+# PostgreSQL connection string used by Prisma (Docker uses host "db" for container networking, "localhost" for direct Prisma CLI commands)
+DATABASE_URL=postgresql://postgres:password@localhost:5432/orbit
+
+# Secret used to sign and verify JWT auth tokens
+JWT_SECRET=your_jwt_secret_here
+
+# Base URL the frontend uses to reach the backend API
 VITE_API_URL=http://localhost:3000
 
 # Allowed frontend origin for CORS (set to the deployed frontend URL in staging/prod)
 CORS_ORIGIN=http://localhost:5173
 
-# Weather location for the dashboard widget (uses Open-Meteo — no API key required)
-# Format: "latitude,longitude" — e.g. New York: "40.7128,-74.0060"
-# Leave unset to disable weather display
-WEATHER_LOCATION="40.7128,-74.0060"
+# Anthropic API key used for the AI dashboard briefing feature
+ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/backend/src/controllers/briefingController.ts
+++ b/backend/src/controllers/briefingController.ts
@@ -6,11 +6,13 @@ export async function getBriefingController(req: Request, res: Response) {
     return res.status(503).json({ success: false, error: "AI briefing is not configured" });
   }
 
-  const { localTime, timezone } = req.body as {
+  const { localTime, timezone, lat, lon } = req.body as {
     localTime?: string;
     timezone?: string;
+    lat?: number;
+    lon?: number;
   };
 
-  const briefing = await generateBriefing(req.userId!, { localTime, timezone });
+  const briefing = await generateBriefing(req.userId!, { localTime, timezone }, lat, lon);
   res.json({ success: true, data: { briefing } });
 }

--- a/backend/src/controllers/dashboardController.ts
+++ b/backend/src/controllers/dashboardController.ts
@@ -4,7 +4,13 @@ import { evaluateStreak, getEarnedBadges, getNextBadge } from "../services/strea
 import { getProfile } from "../services/profileService";
 
 export async function getDashboardController(req: Request, res: Response) {
-  const data = await getDashboardSummary(req.userId!);
+  const lat = req.query.lat !== undefined ? parseFloat(req.query.lat as string) : undefined;
+  const lon = req.query.lon !== undefined ? parseFloat(req.query.lon as string) : undefined;
+  const data = await getDashboardSummary(
+    req.userId!,
+    lat !== undefined && !isNaN(lat) ? lat : undefined,
+    lon !== undefined && !isNaN(lon) ? lon : undefined
+  );
 
   const totalItems = data.tasks.length + data.reminders.length;
   const completed = data.tasks.filter((t) => t.status === "COMPLETED").length

--- a/backend/src/services/briefingService.ts
+++ b/backend/src/services/briefingService.ts
@@ -1,12 +1,14 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { prisma } from "../lib/prisma";
-import { getWeatherFromEnv } from "./weatherService";
+import { getWeather } from "./weatherService";
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
 export async function generateBriefing(
   userId: string,
-  timeContext?: { localTime?: string; timezone?: string }
+  timeContext?: { localTime?: string; timezone?: string },
+  lat?: number,
+  lon?: number
 ): Promise<string> {
   const now = new Date();
   const weekEnd = new Date(now);
@@ -26,7 +28,7 @@ export async function generateBriefing(
       where: { userId, status: "UPCOMING", scheduledAt: { lte: weekEnd, gte: now } },
       orderBy: { scheduledAt: "asc" },
     }),
-    getWeatherFromEnv(),
+    lat !== undefined && lon !== undefined ? getWeather(lat, lon) : Promise.resolve(null),
   ]);
 
   const tz = timeContext?.timezone;

--- a/backend/src/services/dashboardService.ts
+++ b/backend/src/services/dashboardService.ts
@@ -1,7 +1,7 @@
 import { prisma } from "../lib/prisma";
-import { getWeatherFromEnv } from "./weatherService";
+import { getWeather } from "./weatherService";
 
-export async function getDashboardSummary(userId: string) {
+export async function getDashboardSummary(userId: string, lat?: number, lon?: number) {
   const now = new Date();
   const todayStart = new Date(now);
   todayStart.setHours(0, 0, 0, 0);
@@ -19,7 +19,7 @@ export async function getDashboardSummary(userId: string) {
     prisma.reminder.findMany({
       where: { userId, status: "UPCOMING", scheduledAt: { gte: todayStart, lte: todayEnd } },
     }),
-    getWeatherFromEnv(),
+    lat !== undefined && lon !== undefined ? getWeather(lat, lon) : Promise.resolve(null),
   ]);
 
   return { events, tasks, reminders, weather };

--- a/backend/src/services/weatherService.ts
+++ b/backend/src/services/weatherService.ts
@@ -30,16 +30,6 @@ const WMO_DESCRIPTIONS: Record<number, string> = {
   99: "thunderstorm with heavy hail",
 };
 
-export function getWeatherFromEnv(): Promise<Weather | null> {
-  const loc = process.env.WEATHER_LOCATION;
-  if (!loc) return Promise.resolve(null);
-  const [latStr, lonStr] = loc.split(",");
-  const lat = parseFloat(latStr);
-  const lon = parseFloat(lonStr);
-  if (isNaN(lat) || isNaN(lon)) return Promise.resolve(null);
-  return getWeather(lat, lon);
-}
-
 export async function getWeather(lat: number, lon: number): Promise<Weather | null> {
   const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,weather_code&temperature_unit=fahrenheit`;
   const res = await fetch(url);

--- a/backend/test/dashboardService.test.ts
+++ b/backend/test/dashboardService.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockEventFindMany = vi.hoisted(() => vi.fn());
 const mockTaskFindMany = vi.hoisted(() => vi.fn());
 const mockReminderFindMany = vi.hoisted(() => vi.fn());
-const mockGetWeatherFromEnv = vi.hoisted(() => vi.fn());
+const mockGetWeather = vi.hoisted(() => vi.fn());
 
 vi.mock("../src/lib/prisma", () => ({
   prisma: {
@@ -14,7 +14,7 @@ vi.mock("../src/lib/prisma", () => ({
 }));
 
 vi.mock("../src/services/weatherService", () => ({
-  getWeatherFromEnv: mockGetWeatherFromEnv,
+  getWeather: mockGetWeather,
 }));
 
 import { getDashboardSummary } from "../src/services/dashboardService";
@@ -24,10 +24,10 @@ const userId = "user-1";
 describe("getDashboardSummary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetWeatherFromEnv.mockResolvedValue(null);
+    mockGetWeather.mockResolvedValue(null);
   });
 
-  it("returns events, tasks, reminders, and weather as null when WEATHER_LOCATION is unset", async () => {
+  it("returns events, tasks, reminders, and weather as null when no coordinates are provided", async () => {
     const fakeEvents = [{ id: "evt-1", title: "Standup" }];
     const fakeTasks = [{ id: "task-1", title: "Fix bug" }];
     const fakeReminders = [{ id: "rem-1", title: "Call dentist" }];
@@ -44,19 +44,20 @@ describe("getDashboardSummary", () => {
       reminders: fakeReminders,
       weather: null,
     });
+    expect(mockGetWeather).not.toHaveBeenCalled();
   });
 
-  it("fetches weather from env var when WEATHER_LOCATION is set", async () => {
+  it("fetches weather using the provided lat/lon coordinates", async () => {
     const fakeWeather = { temperature: 72, condition: "clear sky" };
     mockEventFindMany.mockResolvedValue([]);
     mockTaskFindMany.mockResolvedValue([]);
     mockReminderFindMany.mockResolvedValue([]);
-    mockGetWeatherFromEnv.mockResolvedValue(fakeWeather);
+    mockGetWeather.mockResolvedValue(fakeWeather);
 
-    const result = await getDashboardSummary(userId);
+    const result = await getDashboardSummary(userId, 40.7128, -74.006);
 
     expect(result.weather).toEqual(fakeWeather);
-    expect(mockGetWeatherFromEnv).toHaveBeenCalled();
+    expect(mockGetWeather).toHaveBeenCalledWith(40.7128, -74.006);
   });
 
   it("queries events within today's UTC boundaries ordered by startAt", async () => {

--- a/frontend/src/components/DatePicker.tsx
+++ b/frontend/src/components/DatePicker.tsx
@@ -87,7 +87,7 @@ export default function DatePicker({
                   key={day}
                   type="button"
                   onClick={() => select(day)}
-                  className={`text-xs py-1 rounded transition-colors duration-100 ${
+                  className={`text-xs py-1 rounded transition-none ${
                     isSelected && isToday
                       ? "bg-white/30 text-white font-medium ring-1 ring-emerald-400/60"
                       : isSelected

--- a/frontend/src/components/DateTimePicker.tsx
+++ b/frontend/src/components/DateTimePicker.tsx
@@ -70,7 +70,7 @@ function TimeSelect({
               key={opt}
               type="button"
               onClick={() => { onChange(opt); setOpen(false); }}
-              className={`block w-full text-left text-xs px-3 py-1 transition-colors duration-100 ${
+              className={`block w-full text-left text-xs px-3 py-1 transition-none ${
                 value === opt ? "bg-white/20 text-white font-medium" : "text-white/70 hover:bg-white/10"
               }`}
             >

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -49,6 +49,17 @@ function formatTime(iso: string) {
   return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
+function getCoords(): Promise<{ lat: number; lon: number } | null> {
+  return new Promise((resolve) => {
+    if (!navigator.geolocation) { resolve(null); return; }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => resolve({ lat: pos.coords.latitude, lon: pos.coords.longitude }),
+      () => resolve(null),
+      { timeout: 5000 }
+    );
+  });
+}
+
 
 function ExpandableTask({
   task,
@@ -186,6 +197,7 @@ export default function DashboardPage() {
   const [newStartAt, setNewStartAt] = useState("");
   const [newEndAt, setNewEndAt] = useState("");
   const widgetGridRef = useRef<HTMLDivElement>(null);
+  const coordsRef = useRef<{ lat: number; lon: number } | null>(null);
 
   useEffect(() => {
     if (editingSlot === null) return;
@@ -213,8 +225,11 @@ export default function DashboardPage() {
 
   useEffect(() => {
     async function load() {
+      const coords = await getCoords();
+      coordsRef.current = coords;
+      const dashPath = coords ? `/api/v1/dashboard?lat=${coords.lat}&lon=${coords.lon}` : "/api/v1/dashboard";
       const [dashRes, eventsRes, taskRes, remRes] = await Promise.all([
-        apiFetch("/api/v1/dashboard"),
+        apiFetch(dashPath),
         apiFetch("/api/v1/events"),
         apiFetch("/api/v1/tasks"),
         apiFetch("/api/v1/reminders"),
@@ -341,9 +356,11 @@ export default function DashboardPage() {
     }
     setBriefingVisible(true);
     setBriefing({ status: "loading" });
+    const coords = coordsRef.current;
     const payload = {
       localTime: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: true }),
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      ...(coords ? { lat: coords.lat, lon: coords.lon } : {}),
     };
     const res = await apiFetch("/api/v1/dashboard/briefing", { method: "POST", body: JSON.stringify(payload) });
     if (!res.ok) {
@@ -508,7 +525,7 @@ export default function DashboardPage() {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             {/* Tasks tile */}
-            <div className="glass-light rounded-xl px-5 py-4 min-h-48">
+            <div className={`glass-light rounded-xl px-5 py-4 min-h-48 ${creating === "task" ? "z-20" : ""}`}>
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-sm font-semibold text-white/60 uppercase tracking-wide">
                   Tasks{dueTasks.length > 0 && <span className="ml-1.5 text-white/30">({dueTasks.length})</span>}
@@ -547,7 +564,7 @@ export default function DashboardPage() {
             </div>
 
             {/* Reminders tile */}
-            <div className="glass-light rounded-xl px-5 py-4 min-h-48">
+            <div className={`glass-light rounded-xl px-5 py-4 min-h-48 ${creating === "reminder" ? "z-20" : ""}`}>
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-sm font-semibold text-white/60 uppercase tracking-wide">
                   Reminders{todayReminders.length > 0 && <span className="ml-1.5 text-white/30">({todayReminders.length})</span>}
@@ -585,7 +602,7 @@ export default function DashboardPage() {
             </div>
 
             {/* Events tile */}
-            <div className="glass-light rounded-xl px-5 py-4 min-h-48">
+            <div className={`glass-light rounded-xl px-5 py-4 min-h-48 ${creating === "event" ? "z-20" : ""}`}>
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-sm font-semibold text-white/60 uppercase tracking-wide">
                   Events{todayEvents.length > 0 && <span className="ml-1.5 text-white/30">({todayEvents.length})</span>}


### PR DESCRIPTION
## Summary
- Revert weather from the fixed `WEATHER_LOCATION` env var back to browser geolocation + Open-Meteo, per #131
- Frontend requests location via `navigator.geolocation` on the Dashboard; passes lat/lon to `/api/v1/dashboard` and the briefing endpoint
- Backend `getWeather(lat, lon)` no longer falls back to an env var; dashboard loads fine with no weather data if location is denied
- Removed `WEATHER_LOCATION` from `.env.example`
- Also includes two small UI fixes found along the way:
  - Dashboard date/time picker dropdowns no longer render behind sibling tiles (z-index fix)
  - Date/time picker hover highlight no longer feels delayed (removed transition on hover)

## Test plan
- [ ] On Dashboard, allow location permission — weather widget should populate
- [ ] Deny location permission — dashboard should still load fine, weather widget shows "No weather data"
- [ ] AI briefing should mention current weather when location is available
- [ ] Open a date/time field on Tasks, Reminders, or Calendar — dropdown should render above other tiles, not behind them
- [ ] Hover across date picker grid — highlight should feel instant, not delayed

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)